### PR TITLE
Add configurable somatic SNV callers

### DIFF
--- a/config/day_profiles/local/templates/rule_config.yaml
+++ b/config/day_profiles/local/templates/rule_config.yaml
@@ -34,6 +34,9 @@ valid_biome: AWSPC
 #    - sentd
 #    - lfq2
 
+#snv_callers_somatic:
+#    - ""
+
 #sv_callers:
 #    - tiddit
 #    - manta

--- a/config/day_profiles/slurm/templates/rule_config.yaml
+++ b/config/day_profiles/slurm/templates/rule_config.yaml
@@ -34,6 +34,9 @@ valid_biome: AWSPC
 #    - sentd
 #    - lfq2
 
+#snv_callers_somatic:
+#    - ""
+
 #sv_callers:
 #    - tiddit
 #    - manta

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -2,6 +2,9 @@
 pizzazz: "off"  # on or off
 profile_name: "global"  # this is over-ridden when profile specific config is included
 
+snv_callers_somatic:
+  - ""
+
 
 logs:
     operational:

--- a/workflow/rules/rule_common.smk
+++ b/workflow/rules/rule_common.smk
@@ -149,6 +149,25 @@ else:
         f"""colr 'SNV Callers:{snv_CALLERS}' "$DY_WT1" "$DY_B1" "$DY_WS1" 1>&2;"""
     )
 
+somatic_snv_CALLERS = []
+if 'snv_callers_somatic' not in config:
+    os.system(
+        f'''colr "...WARNING: No snv_callers_somatic set in the config." "$DY_WT1" "$DY_WB1" "$DY_WS1" 1>&2'''
+    )
+else:
+    somatic_snv_CALLERS = sorted(
+        set(
+            []
+            if 'snv_callers_somatic' not in config
+            or config['snv_callers_somatic'] is None
+            else config["snv_callers_somatic"]
+        )
+    )
+    ## PRINT INFO
+    os.system(
+        f"""colr 'Somatic SNV Callers:{somatic_snv_CALLERS}' "$DY_WT1" "$DY_B1" "$DY_WS1" 1>&2;"""
+    )
+
 sv_CALLERS = []
 if 'sv_callers' not in config:
 


### PR DESCRIPTION
## Summary
- support dedicated `snv_callers_somatic` config option
- expose new `somatic_snv_CALLERS` array in workflow
- document optional `snv_callers_somatic` in profile templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a742d843d88331b638e2a069da2499