### PR TITLE
feat: handle missing tumor normal pairing column

### DIFF
--- a/config/day_examples/vanilla_analysis_manifest/README.md
+++ b/config/day_examples/vanilla_analysis_manifest/README.md
@@ -13,7 +13,7 @@ The manifest should be saved in the config dirwith the follwing name: 'analysis_
 
   * 9 Required colmns which must have non-null values
   * 8 Required columns which may have null(na) values
-  *  supported columns, 16 of which must be present and at leaset have an 'na' entry (no empty string fields are permittted in any colum found in the manifest.) :
+  *  supported columns, 15 of which must be present and at leaset have an 'na' entry (no empty string fields are permittted in any colum found in the manifest.) The `tum_nrm_sampleid_match` column is optional; if omitted or left blank, it is treated as `na`.
 
 sample,sample_lane,SQ,RU,EX,LANE,r1_path,r2_path,biological_sex,iddna_uid,concordance_control_path,is_positive_control,is_negative_control,sample_type,merge_single,tum_nrm_sampleid_match,external_sample_id,remote_bam_file_path,rclone_handle
   - _the columns should be in this order as well_

--- a/workflow/rules/rule_common.smk
+++ b/workflow/rules/rule_common.smk
@@ -244,6 +244,16 @@ samples = pd.read_table(analysis_manifest, ",").set_index(
     ["sample", "sample_lane"], drop=False
 )
 
+# Ensure tum_nrm_sampleid_match exists and treat missing values as 'na'
+if "tum_nrm_sampleid_match" in samples.columns:
+    samples["tum_nrm_sampleid_match"] = samples["tum_nrm_sampleid_match"].apply(
+        lambda x: "na"
+        if pd.isna(x) or str(x).strip().lower() in {"", "na"}
+        else str(x).strip()
+    )
+else:
+    samples["tum_nrm_sampleid_match"] = "na"
+
 # validate the analysis_manifest.csv with the appropriate yaml schema
 validate(samples, schema="../schemas/analysis_manifest.schema.yaml")
 

--- a/workflow/schemas/analysis_manifest.schema.yaml
+++ b/workflow/schemas/analysis_manifest.schema.yaml
@@ -73,5 +73,4 @@ required:
     - is_negative_control
     - sample_type
     - merge_single
-    - tum_nrm_sampleid_match
 


### PR DESCRIPTION
## Summary
- treat missing `tum_nrm_sampleid_match` values as `na`
- allow manifests without `tum_nrm_sampleid_match`
- document optional tumor/normal pairing column

## Testing
- `python -m py_compile workflow/rules/rule_common.smk`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad64bda0c08331a7dd50e704185deb