### PR TITLE
Add standalone coverage evenness script

### DIFF
--- a/bin/calc_coverage_evenness_two.py
+++ b/bin/calc_coverage_evenness_two.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Calculate coverage evenness metrics over windows.
+
+Reads `samtools depth` output from STDIN and writes windowed metrics to STDOUT.
+The metrics match those produced by the previous gawk implementation in
+``workflow/rules/calc_coverage_evenness_two.smk``.
+
+Example
+-------
+    samtools depth -a sample.cram | \
+        bin/calc_coverage_evenness_two.py --window 100000 > metrics.tsv
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from statistics import median
+from typing import Iterable, List
+
+
+def process_window(chrom: str, start: int, depths: List[float], out):
+    """Compute and write metrics for a window of depths."""
+    count = len(depths)
+    if count == 0:
+        return
+
+    mean = sum(depths) / count
+    med = median(depths)
+    sumsq = sum((d - mean) ** 2 for d in depths)
+    sd = math.sqrt(sumsq / count) if count > 0 else 0.0
+    cv = sd / mean if mean > 0 else 0.0
+    even = math.exp(-cv)
+
+    thr20 = 0.2 * mean
+    thr50 = 0.5 * mean
+    gt20 = sum(1 for d in depths if d >= thr20)
+    gt50 = sum(1 for d in depths if d >= thr50)
+    pct20 = 100 * gt20 / count
+    pct50 = 100 * gt50 / count
+
+    end = start + count - 1
+    out.write(
+        f"{chrom}\t{start}\t{end}\t{mean:.4f}\t{med:.4f}\t{sd:.4f}\t{cv:.4f}\t{even:.4f}\t{pct20:.2f}\t{pct50:.2f}\n"
+    )
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-w",
+        "--window",
+        type=int,
+        default=100000,
+        help="Number of positions per window (default: 100000)",
+    )
+    args = parser.parse_args(argv)
+
+    out = sys.stdout
+    out.write(
+        "chrom\tstart\tend\tmean\tmedian\tstdev\tcv\tevenness\tpct_gt_0.2xmean\tpct_gt_0.5xmean\n"
+    )
+
+    current_chrom = None
+    start_pos = None
+    depths: List[float] = []
+    expected_pos = None
+
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        chrom, pos_s, depth_s = line.split()[:3]
+        pos = int(pos_s)
+        depth = float(depth_s)
+
+        if current_chrom is None:
+            current_chrom = chrom
+            start_pos = pos
+            expected_pos = pos
+
+        flush = False
+        if chrom != current_chrom:
+            flush = True
+        elif len(depths) >= args.window or (expected_pos is not None and pos > expected_pos):
+            flush = True
+
+        if flush:
+            process_window(current_chrom, start_pos, depths, out)
+            depths = []
+            current_chrom = chrom
+            start_pos = pos
+
+        depths.append(depth)
+        expected_pos = pos + 1
+
+    if depths:
+        process_window(current_chrom, start_pos, depths, out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow/rules/calc_coverage_evenness_two.smk
+++ b/workflow/rules/calc_coverage_evenness_two.smk
@@ -22,42 +22,7 @@ rule calc_coverage_evenness_two:
         set -euo pipefail;
         mkdir -p $(dirname {output.metrics}) $(dirname {log});
         samtools depth -a {input.cram} 2> {log} | \
-        gawk -v W={params.window} '
-        BEGIN{{
-            OFS="\t";
-            print "chrom","start","end","mean","median","stdev","cv","evenness","pct_gt_0.2xmean","pct_gt_0.5xmean"
-        }}
-        function process(chrom,start,count,   i,sum,sumsq,mean,median,sd,cv,even,thr20,thr50,gt20,gt50,sorted,end,pct20,pct50){{
-            if (count==0) return;
-            sum=0; for(i=1;i<=count;i++) sum+=depths[i];
-            mean=sum/count;
-            n=asort(depths,sorted);
-            if (n%2)  median=sorted[(n+1)/2];
-            else      median=(sorted[n/2]+sorted[n/2+1])/2;
-            sumsq=0; for(i=1;i<=count;i++) sumsq+=(depths[i]-mean)^2;
-            sd=(count>0)?sqrt(sumsq/count):0;   # population stdev; use (count-1) for sample stdev
-            cv=(mean>0)?sd/mean:0;
-            even=exp(-cv);
-            thr20=0.2*mean; thr50=0.5*mean;
-            gt20=gt50=0;
-            for(i=1;i<=count;i++){{ if (depths[i]>=thr20) gt20++; if (depths[i]>=thr50) gt50++; }}
-            pct20=100*gt20/count; pct50=100*gt50/count;
-            end=start+count-1;
-            printf "%s\t%d\t%d\t%.4f\t%.4f\t%.4f\t%.4f\t%.4f\t%.2f\t%.2f\n",
-                chrom,start,end,mean,median,sd,cv,even,pct20,pct50;
-        }}
-        {{
-            chrom=$1; pos=$2; depth=$3+0;
-            if (cchrom=="") {{ cchrom=chrom; start=pos; }}
-            # flush on chrom change, full window, or a position gap
-            if (chrom!=cchrom || count>=W || pos>start+count) {{
-                process(cchrom,start,count);
-                delete depths; count=0; cchrom=chrom; start=pos;
-            }}
-            depths[++count]=depth;
-        }}
-        END{{ process(cchrom,start,count); }}
-        ' > {output.metrics};
+            bin/calc_coverage_evenness_two.py --window {params.window} > {output.metrics};
         {latency_wait};
         ls {output.metrics};
     """


### PR DESCRIPTION
## Summary
- add `bin/calc_coverage_evenness_two.py` to compute coverage evenness metrics
- update `calc_coverage_evenness_two` Snakemake rule to use the new Python script instead of embedded gawk

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad75c0ede483319aeb6e4c11ec0d0c