### PR TITLE
Use BAM inputs for Mutect2

### DIFF
--- a/workflow/rules/mutect2.smk
+++ b/workflow/rules/mutect2.smk
@@ -38,27 +38,87 @@ rule mutect2_bams:
         r"""
         set -euo pipefail
         ulimit -n 65536 || true
+        
+        mkdir -p "$(dirname {output.tumor_bam}"
 
-        mkdir -p "$(dirname {output.tumor_bam})"
+        # Build interval token; map 23→X, 24→Y, 25→{params.mito_code}; strip trailing colon.
+        tchr=$(echo {params.cpre}{params.chrm} \
+        | sed 's/~/\:/g' | sed 's/23\:/X\:/' | sed 's/24\:/Y\:/' | sed 's/25\:/{params.mito_code}\:/')
+        tchr=${{tchr}}
 
-        tchr=$(echo {params.cpre}{params.chrm} | sed 's/~/\:/g' | sed 's/23\:/X\:/' | sed 's/24\:/Y\:/' | sed 's/25\:/{params.mito_code}\:/')
-        tchr=${{tchr%:}}
         IFS=':' read -r tcontig tstart tend <<< "$tchr"
-        if [ -z "${{tend:-}}" ]; then
-            tstart=0
-            tend=$(awk -v c="$tcontig" '$1==c{{print $2; exit}}' {input.ref_fai})
-            region="$tcontig"
-        else
-            region="$tcontig:$tstart-$tend"
+
+        # Look up contig length early
+        contig_len=$(awk -v c="$tcontig" '$1==c{{print $2; exit}}' {input.ref_fai})
+        if [ -z "${{contig_len}}" ]; then
+          echo "ERROR: Contig '$tcontig' not found in {input.ref_fai}" >&2
+          exit 1
         fi
 
+        if [ -z "${{tend}}" ]; then
+          # Whole contig
+          region="$tcontig"
+        else
+          # Normalize to 1-based inclusive and clamp to [1, contig_len]
+          if [ -z "${{tstart}}" ] || [ "$tstart" -lt 1 ]; then tstart=1; fi
+          if [ "$tend" -gt "$contig_len" ]; then tend="$contig_len"; fi
+          if [ "$tstart" -gt "$tend" ]; then
+            echo "ERROR: Empty/invalid interval after normalization: $tcontig:$tstart-$tend" >&2
+            exit 1
+          fi
+          region="$tcontig:$tstart-$tend"
+        fi
+        
+        # Tumor
         samtools view -@ {threads} -T {input.ref_fa} -b {input.tumor_cram} "$region" \
-            | samtools sort -@ {threads} -o {output.tumor_bam} -           >> {log} 2>&1
-        samtools index -@ {threads} {output.tumor_bam}                      >> {log} 2>&1
-
+          | samtools sort -@ {threads} -o {output.tumor_bam} -           >> {log} 2>&1
+        samtools index -@ {threads} {output.tumor_bam}                    >> {log} 2>&1
+        
+        # Normal
         samtools view -@ {threads} -T {input.ref_fa} -b {input.normal_cram} "$region" \
-            | samtools sort -@ {threads} -o {output.normal_bam} -          >> {log} 2>&1
-        samtools index -@ {threads} {output.normal_bam}                     >> {log} 2>&1
+          | samtools sort -@ {threads} -o {output.normal_bam} -          >> {log} 2>&1
+        samtools index -@ {threads} {output.normal_bam}                   >> {log} 2>&1
+
+
+        # ---- Fix SM in headers (preserve all other @RG fields) ----
+        fix_sm () {{
+          inbam=$1
+          outbam=$2
+          sm=$3
+          tmphdr=$(mktemp)
+          OFS="\t"
+          samtools view -H "$inbam" \
+            | awk -v sm="$sm" 'BEGIN{OFS="\t"}
+                /^@RG/ {
+                  hasSM=0
+                  for (i=1;i<=NF;i++){
+                    if ($i ~ /^SM:/) { $i="SM:" sm; hasSM=1 }
+                  }
+                  if (!hasSM){ $0 = $0 OFS "SM:" sm }
+                }
+                { print }
+              ' > "$tmphdr"
+          # Reheader and replace atomically
+          samtools reheader "$tmphdr" "$inbam" > "$outbam"
+          rm -f "$tmphdr"
+          samtools index -@ {threads} "$outbam" >/dev/null 2>&1 || true
+        }}
+        
+        # Distinct names for tumor/normal (required by Mutect2)
+        T_SM="{params.cluster_sample}-T"
+        N_SM="{params.cluster_sample}-N"
+        
+        fix_sm "{output.tumor_bam}"  "{output.tumor_bam}.smfix" "$T_SM"
+        mv "{output.tumor_bam}.smfix" "{output.tumor_bam}"
+        samtools index -@ {threads} -f "{output.tumor_bam}"                     >> {log} 2>&1
+        
+        fix_sm "{output.normal_bam}" "{output.normal_bam}.smfix" "$N_SM"
+        mv "{output.normal_bam}.smfix" "{output.normal_bam}"
+        samtools index -@ {threads} -f "{output.normal_bam}"                    >> {log} 2>&1
+        
+        # Optional: log the final names for sanity  
+        gatk GetSampleName -I {output.tumor_bam} 2>>{log} | sed "s/^/Tumor SM: /"  >> {log}
+        gatk GetSampleName -I {output.normal_bam} 2>>{log} | sed "s/^/Normal SM: /" >> {log}
         """
 
 rule mutect2:
@@ -110,7 +170,8 @@ rule mutect2:
             tstart=0
             tend=$(awk -v c="$tcontig" '$1==c{{print $2; exit}}' {params.huref}.fai)
         fi
-        region="$tcontig:$tstart-$tend"
+        #region="$tcontig:$tstart-$tend"
+        region="$tcontig "
 
         gatk --java-options "-Xmx{resources.mem_mb}M" Mutect2 \
             -R {params.huref} \

--- a/workflow/rules/mutect2.smk
+++ b/workflow/rules/mutect2.smk
@@ -4,7 +4,7 @@ import os
 ##### mutect2
 # ---------------------------
 
-rule mutect2:
+rule mutect2_bams:
     wildcard_constraints:
         sample=TUMORS_REGEX
     input:
@@ -12,6 +12,63 @@ rule mutect2:
         tumor_crai=get_somcall_tumor_crai,
         normal_cram=get_somcall_normal_cram,
         normal_crai=get_somcall_normal_crai,
+        ref_fa=lambda wc: config["supporting_files"]["files"]["huref"]["fasta"]["name"],
+        ref_fai=lambda wc: config["supporting_files"]["files"]["huref"]["fasta"]["name"] + ".fai",
+    output:
+        tumor_bam=temp(MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.tumor.bam"),
+        tumor_bai=temp(MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.tumor.bam.bai"),
+        normal_bam=temp(MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.normal.bam"),
+        normal_bai=temp(MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.normal.bam.bai"),
+    log:
+        MDIR + "{sample}/align/{alnr}/snv/mutect2/log/{sample}.{alnr}.mutect2.{m2chrm}.bamify.log",
+    threads: config['mutect2']['threads']
+    conda: "../envs/vanilla_v0.1.yaml"
+    params:
+        huref=config["supporting_files"]["files"]["huref"]["fasta"]["name"],
+        cpre="" if "b37" == config['genome_build'] else "chr",
+        mito_code="MT" if "b37" == config['genome_build'] else "M",
+        chrm=get_mutect2_chrm_day,
+        cluster_sample=ret_sample,
+    resources:
+        vcpu=config['mutect2']['threads'],
+        threads=config['mutect2']['threads'],
+        partition=config['mutect2']['partition'],
+        mem_mb=config['mutect2']['mem_mb'],
+    shell:
+        r"""
+        set -euo pipefail
+        ulimit -n 65536 || true
+
+        mkdir -p "$(dirname {output.tumor_bam})"
+
+        tchr=$(echo {params.cpre}{params.chrm} | sed 's/~/\:/g' | sed 's/23\:/X\:/' | sed 's/24\:/Y\:/' | sed 's/25\:/{params.mito_code}\:/')
+        tchr=${{tchr%:}}
+        IFS=':' read -r tcontig tstart tend <<< "$tchr"
+        if [ -z "${{tend:-}}" ]; then
+            tstart=0
+            tend=$(awk -v c="$tcontig" '$1==c{{print $2; exit}}' {input.ref_fai})
+            region="$tcontig"
+        else
+            region="$tcontig:$tstart-$tend"
+        fi
+
+        samtools view -@ {threads} -T {input.ref_fa} -b {input.tumor_cram} "$region" \
+            | samtools sort -@ {threads} -o {output.tumor_bam} -           >> {log} 2>&1
+        samtools index -@ {threads} {output.tumor_bam}                      >> {log} 2>&1
+
+        samtools view -@ {threads} -T {input.ref_fa} -b {input.normal_cram} "$region" \
+            | samtools sort -@ {threads} -o {output.normal_bam} -          >> {log} 2>&1
+        samtools index -@ {threads} {output.normal_bam}                     >> {log} 2>&1
+        """
+
+rule mutect2:
+    wildcard_constraints:
+        sample=TUMORS_REGEX
+    input:
+        tumor_bam=MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.tumor.bam",
+        tumor_bai=MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.tumor.bam.bai",
+        normal_bam=MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.normal.bam",
+        normal_bai=MDIR + "{sample}/align/{alnr}/snv/mutect2/tmp/{m2chrm}/{sample}.{alnr}.mutect2.{m2chrm}.normal.bam.bai",
         ref_fa=lambda wc: config["supporting_files"]["files"]["huref"]["fasta"]["name"],
         ref_fai=lambda wc: config["supporting_files"]["files"]["huref"]["fasta"]["name"] + ".fai",
         d=MDIR + "{sample}/align/{alnr}/snv/mutect2/vcfs/{m2chrm}/{sample}.ready",
@@ -57,8 +114,8 @@ rule mutect2:
 
         gatk --java-options "-Xmx{resources.mem_mb}M" Mutect2 \
             -R {params.huref} \
-            -I {input.tumor_cram} -tumor {params.tumor_sample} \
-            -I {input.normal_cram} -normal {params.normal_sample} \
+            -I {input.tumor_bam} -tumor {params.tumor_sample} \
+            -I {input.normal_bam} -normal {params.normal_sample} \
             -L $region \
             -O {output.vcf} >> {log} 2>&1
         """


### PR DESCRIPTION
## Summary
- add preprocessing rule to convert CRAM inputs to temporary BAMs for Mutect2
- run Mutect2 using BAM inputs instead of CRAM to avoid CRAM 3.1 issue

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfc89f30b48331bbc5a80b6e11b266