### PR TITLE
fix mutect2 sample name reheader

### DIFF
--- a/workflow/rules/mutect2.smk
+++ b/workflow/rules/mutect2.smk
@@ -86,17 +86,14 @@ rule mutect2_bams:
           outbam=$2
           sm=$3
           tmphdr=$(mktemp)
-          OFS="\t"
           samtools view -H "$inbam" \
-            | awk -v sm="$sm" 'BEGIN{OFS="\t"}
-                /^@RG/ {
-                  hasSM=0
-                  for (i=1;i<=NF;i++){
-                    if ($i ~ /^SM:/) { $i="SM:" sm; hasSM=1 }
-                  }
-                  if (!hasSM){ $0 = $0 OFS "SM:" sm }
-                }
-                { print }
+            | awk -v sm="$sm" 'BEGIN{{FS=OFS="\t"}}
+                /^@RG/ {{
+                  found=0
+                  for (i=1;i<=NF;i++) if ($i ~ /^SM:/) {{ $i="SM:" sm; found=1 }}
+                  if (!found) {{ $0 = $0 OFS "SM:" sm }}
+                }}
+                {{ print }}
               ' > "$tmphdr"
           # Reheader and replace atomically
           samtools reheader "$tmphdr" "$inbam" > "$outbam"


### PR DESCRIPTION
## Summary
- simplify BAM sample name correction in mutect2_bams to avoid Snakemake formatting errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd13de3488331b491725c2e089b04