### PR TITLE
Add Somalier/Picard/Conpair relatedness QC workflow

### DIFF
--- a/config/relatedness.yaml
+++ b/config/relatedness.yaml
@@ -1,0 +1,49 @@
+# Example configuration for relatedness QC workflow
+ref_fasta: /path/to/GRCh38.fa
+
+somalier:
+  sites_vcf: /path/to/somalier-sites-hg38.vcf.bgz
+  genome_build: GRCh38
+
+picard:
+  haplotype_map: /path/to/haplotype_map_hg38.vcf.gz
+
+conpair:
+  snp_positions_bed: /path/to/Conpair/snp_positions_hg38.bed
+  common_sites_vcf: /path/to/Conpair/common_snps_hg38.vcf.gz
+  min_baseq: 20
+  min_mapq: 10
+
+samples:
+  HG001_N1:
+    bam: /data/HG001/normal1.bam
+  HG001_N2:
+    bam: /data/HG001/normal2.bam
+  PT1_T:
+    bam: /data/PT1/tumor.bam
+  PT1_N:
+    bam: /data/PT1/normal.bam
+  FATHER:
+    vcf: /data/family/joint.vcf.gz
+  MOTHER:
+    vcf: /data/family/joint.vcf.gz
+  CHILD:
+    vcf: /data/family/joint.vcf.gz
+
+expected:
+  - relationship: identical
+    samples: [HG001_N1, HG001_N2]
+  - relationship: tumor_normal
+    samples: [PT1_T, PT1_N]
+  - relationship: parent_child
+    samples: [FATHER, CHILD]
+  - relationship: parent_child
+    samples: [MOTHER, CHILD]
+  - relationship: siblings
+    samples: [FATHER, MOTHER]
+    note: "should NOT be siblings -> expect fail"
+
+peddy:
+  enabled: false
+  joint_vcf: /data/family/joint.vcf.gz
+  ped: /data/family/family.ped

--- a/workflow/envs/conpair.yaml
+++ b/workflow/envs/conpair.yaml
@@ -1,0 +1,13 @@
+name: conpair
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.9
+  - samtools
+  - pysam
+  - pandas
+  - numpy
+  - pip
+  - pip:
+      - git+https://github.com/nygenome/Conpair.git

--- a/workflow/envs/peddy.yaml
+++ b/workflow/envs/peddy.yaml
@@ -1,0 +1,9 @@
+name: peddy
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - peddy
+  - cython
+  - pandas
+  - python>=3.9

--- a/workflow/envs/picard.yaml
+++ b/workflow/envs/picard.yaml
@@ -1,0 +1,7 @@
+name: picard
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - picard=3.*
+  - openjdk=17

--- a/workflow/envs/report.yaml
+++ b/workflow/envs/report.yaml
@@ -1,0 +1,10 @@
+name: relatedness-report
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python>=3.9
+  - pandas
+  - numpy
+  - jinja2
+  - pyyaml

--- a/workflow/envs/somalier.yaml
+++ b/workflow/envs/somalier.yaml
@@ -1,0 +1,10 @@
+name: somalier
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - somalier=0.2*
+  - htslib
+  - bcftools
+  - samtools
+  - python>=3.9

--- a/workflow/rules/relatedness_test_day.smk
+++ b/workflow/rules/relatedness_test_day.smk
@@ -1,4 +1,4 @@
-import os, yaml
+import os
 
 configfile: "config/relatedness.yaml"
 
@@ -8,110 +8,116 @@ REF = config["ref_fasta"]
 GENOME_BUILD = config["somalier"].get("genome_build", "GRCh38")
 HAPMAP = config["picard"]["haplotype_map"]
 
-# Decide input type for each sample
-def sample_input(sample):
-    ent = config["samples"][sample]
-    if "bam" in ent:
-        return ent["bam"], "bam"
-    elif "vcf" in ent:
-        return ent["vcf"], "vcf"
-    else:
-        raise ValueError(f"Sample {sample} must have 'bam' or 'vcf' path.")
 
-# Somalier extract outputs
+def sample_input(sample):
+    """Return the configured path and input type for a sample."""
+    entry = config["samples"][sample]
+    if "bam" in entry:
+        return entry["bam"], "bam"
+    if "vcf" in entry:
+        return entry["vcf"], "vcf"
+    raise ValueError(f"Sample {sample} must have 'bam' or 'vcf' path.")
+
+
 SomExtract = expand("results/somalier/extract/{sample}.somalier", sample=SAMPLES)
+
 
 rule relatedness_all:
     input:
-        # Somalier relatedness
         "results/somalier/cohort_pairs.tsv",
         "results/somalier/cohort_groups.tsv",
         "results/somalier/cohort.html",
-        # Picard crosscheck (matrix + metrics)
         "results/picard/crosscheck/metrics.txt",
         "results/picard/crosscheck/matrix.txt",
-        # Conpair for tumor/normal pairs detected from sample IDs
         expand(
-            "results/conpair/{t}__{n}/concordance.tsv",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
+            "results/conpair/{a}__{b}/concordance.tsv",
+            zip,
+            a=[x["samples"][0] for x in config.get("expected", []) if x["relationship"] == "tumor_normal"],
+            b=[x["samples"][1] for x in config.get("expected", []) if x["relationship"] == "tumor_normal"],
         ),
-        # Optional peddy
-        *( ["results/peddy/peddy.html"] if config.get("peddy", {}).get("enabled", False) else [] ),
-        # Final merged report
+        *(
+            ["results/peddy/peddy.html"]
+            if config.get("peddy", {}).get("enabled", False)
+            else []
+        ),
         "results/relatedness_qc/relatedness_summary.tsv",
-        "results/relatedness_qc/relatedness_report.html"
+        "results/relatedness_qc/relatedness_report.html",
+
 
 #######################################################################
 # SOMALIER
 #######################################################################
 
 rule somalier_extract:
-    """
-    Build per-sample fingerprint from BAM/CRAM (preferred) or VCF.
-    """
-    output: "results/somalier/extract/{sample}.somalier"
+    """Build per-sample fingerprint from BAM/CRAM (preferred) or VCF."""
+
+    output:
+        "results/somalier/extract/{sample}.somalier"
     params:
         sites=SOM_SITES,
         build=GENOME_BUILD
     threads: 4
-    conda: "../envs/somalier_v0.1.yaml"
+    conda: "../envs/somalier.yaml"
     shell:
         r"""
-        if [[ "{sample_input(wildcards.samp)[1]}" == "bam" ]]; then
+        if [[ "{sample_input(wildcards.sample)[1]}" == "bam" ]]; then
             somalier extract \
               --sites {params.sites} \
               --fasta {REF} \
               --genome-build {params.build} \
               -o results/somalier/extract/{wildcards.sample} \
-              {sample_input(wildcards.samp)[0]}
+              {sample_input(wildcards.sample)[0]}
         else
             somalier extract \
               --sites {params.sites} \
               --genome-build {params.build} \
               -o results/somalier/extract/{wildcards.sample} \
-              {sample_input(wildcards.samp)[0]} \
-              --unknown   # treat missing as hom-ref when VCF lacks some sites
+              {sample_input(wildcards.sample)[0]} \
+              --unknown
         fi
         """
 
+
 rule somalier_relate:
-    input: SomExtract
+    input:
+        SomExtract
     output:
         pairs="results/somalier/cohort_pairs.tsv",
         groups="results/somalier/cohort_groups.tsv",
         html="results/somalier/cohort.html"
-    conda: "../envs/somalier_v0.1.yaml"
+    conda: "../envs/somalier.yaml"
     shell:
         r"""
         somalier relate results/somalier/extract/*.somalier -o results/somalier/cohort
         """
 
+
 #######################################################################
 # PICARD CrosscheckFingerprints
 #######################################################################
 
-# Build a file list for picard (one input per line)
 rule picard_build_input_list:
-    output: "results/picard/crosscheck/input.list"
+    output:
+        "results/picard/crosscheck/input.list"
     run:
         os.makedirs("results/picard/crosscheck", exist_ok=True)
-        with open(output[0], "w") as fh:
-            for s in SAMPLES:
-                path, typ = sample_input(s)
-                fh.write(path + "\n")
+        with open(output[0], "w") as handle:
+            for sample in SAMPLES:
+                path, _ = sample_input(sample)
+                handle.write(path + "\n")
+
 
 rule picard_crosscheck:
-    input: "results/picard/crosscheck/input.list"
+    input:
+        "results/picard/crosscheck/input.list"
     output:
         metrics="results/picard/crosscheck/metrics.txt",
         matrix="results/picard/crosscheck/matrix.txt"
     params:
         hapmap=HAPMAP
-    conda: "../envs/picard_relatedness_v0.1.yaml"
+    conda: "../envs/picard.yaml"
     shell:
         r"""
-        # CROSSCHECK_BY=FILE => all-vs-all across inputs in list
         picard CrosscheckFingerprints \
           INPUT_LIST={input} \
           HAPLOTYPE_MAP={params.hapmap} \
@@ -123,33 +129,24 @@ rule picard_crosscheck:
           VALIDATION_STRINGENCY=SILENT
         """
 
+
 #######################################################################
-# CONPAIR (for tumor/normal pairs inferred from sample IDs)
+# CONPAIR (only for declared tumor_normal expected pairs)
 #######################################################################
+
 
 def tn_pairs():
-    """Identify tumor/normal pairs based on sample naming.
+    return [
+        entry["samples"]
+        for entry in config.get("expected", [])
+        if entry["relationship"] == "tumor_normal"
+    ]
 
-    Samples ending with `_T` are assumed to be tumor and paired with a
-    corresponding sample ending with `_N` that shares the same prefix.
-    Only pairs for which both sample IDs exist and their associated files
-    are present on disk are returned.
-    """
-    pairs = []
-    for s in SAMPLES:
-        if s.endswith("_T"):
-            n = f"{s[:-2]}_N"
-            if n in SAMPLES:
-                t_path, _ = sample_input(s)
-                n_path, _ = sample_input(n)
-                if os.path.exists(t_path) and os.path.exists(n_path):
-                    pairs.append((s, n))
-    return pairs
 
 rule conpair_mpileup:
     input:
-        tumor=lambda wc: sample_input(wc.t)[0],
-        normal=lambda wc: sample_input(wc.n)[0]
+        tumor=lambda wildcards: sample_input(wildcards.t)[0],
+        normal=lambda wildcards: sample_input(wildcards.n)[0]
     output:
         tumor="results/conpair/{t}__{n}/tumor.mpileup",
         normal="results/conpair/{t}__{n}/normal.mpileup"
@@ -157,7 +154,7 @@ rule conpair_mpileup:
         bed=config["conpair"]["snp_positions_bed"],
         mapq=config["conpair"]["min_mapq"],
         baseq=config["conpair"]["min_baseq"]
-    conda: "../envs/conpair_v0.1.yaml"
+    conda: "../envs/conpair.yaml"
     threads: 4
     shell:
         r"""
@@ -166,6 +163,7 @@ rule conpair_mpileup:
         samtools mpileup -l {params.bed} -q {params.mapq} -Q {params.baseq} -f {REF} {input.normal} > {output.normal}
         """
 
+
 rule conpair_parse:
     input:
         tumor="results/conpair/{t}__{n}/tumor.mpileup",
@@ -173,12 +171,13 @@ rule conpair_parse:
     output:
         tparsed="results/conpair/{t}__{n}/tumor.parsed",
         nparsed="results/conpair/{t}__{n}/normal.parsed"
-    conda: "../envs/conpair_v0.1.yaml"
+    conda: "../envs/conpair.yaml"
     shell:
         r"""
         parse_pileup.py -i {input.tumor} -o {output.tparsed}
         parse_pileup.py -i {input.normal} -o {output.nparsed}
         """
+
 
 rule conpair_compare:
     input:
@@ -187,11 +186,10 @@ rule conpair_compare:
     output:
         conctsv="results/conpair/{t}__{n}/concordance.tsv",
         summary="results/conpair/{t}__{n}/summary.txt"
-    conda: "../envs/conpair_v0.1.yaml"
+    conda: "../envs/conpair.yaml"
     shell:
         r"""
         compare.py -t {input.tparsed} -n {input.nparsed} -o results/conpair/{wildcards.t}__{wildcards.n}/res
-        # Conpair writes multiple files; normalize to our outputs:
         if [[ -f results/conpair/{wildcards.t}__{wildcards.n}/res_concordance_summary.txt ]]; then
             cp results/conpair/{wildcards.t}__{wildcards.n}/res_concordance_summary.txt {output.summary}
         fi
@@ -201,72 +199,37 @@ rule conpair_compare:
         """
 
 
-
-
 #######################################################################
 # PEDDY (optional; requires a joint VCF)
 #######################################################################
-rule conpair_mpileup_all:
-    input:
-        expand(
-            "results/conpair/{t}__{n}/tumor.mpileup",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
-        ),
-        expand(
-            "results/conpair/{t}__{n}/normal.mpileup",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
-        )
 
-rule conpair_parse_all:
-    input:
-        expand(
-            "results/conpair/{t}__{n}/tumor.parsed",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
-        ),
-        expand(
-            "results/conpair/{t}__{n}/normal.parsed",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
-        )
 
-rule conpair_compare_all:
+rule peddy:
     input:
-        expand(
-            "results/conpair/{t}__{n}/concordance.tsv",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
-        ),
-        expand(
-            "results/conpair/{t}__{n}/summary.txt",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
-        )
-
-rule peddy_relatedness:
-    input:
-        vcf=lambda wc: config["peddy"]["joint_vcf"],
-        ped=lambda wc: config["peddy"]["ped"]
+        vcf=lambda wildcards: config.get("peddy", {}).get("joint_vcf", ""),
+        ped=lambda wildcards: config.get("peddy", {}).get("ped", "")
     output:
         html="results/peddy/peddy.html"
-    conda: "../envs/peddy_relatedness_v0.1.yaml"
+    conda: "../envs/peddy.yaml"
     threads: 4
-    shell:
-        r"""
-        mkdir -p results/peddy
-        if [ "{config[peddy][enabled]}" = "False" ] || [ -z "{config[peddy][enabled]}" ]; then
-            echo "<html><body>Peddy disabled</body></html>" > {output.html}
-        else
-            peddy -p {threads} --plot --prefix results/peddy/peddy {input.vcf} {input.ped}
-        fi
-        """
+    run:
+        if not config.get("peddy", {}).get("enabled", False):
+            os.makedirs("results/peddy", exist_ok=True)
+            with open(output.html, "w", encoding="utf-8") as handle:
+                handle.write("<html><body>Peddy disabled</body></html>")
+        else:
+            shell(
+                """
+                mkdir -p results/peddy
+                peddy -p {threads} --plot --prefix results/peddy/peddy {input.vcf} {input.ped}
+                """
+            )
 
 
 #######################################################################
 # FINAL MERGED REPORT
 #######################################################################
+
 
 rule relatedness_report:
     input:
@@ -275,24 +238,22 @@ rule relatedness_report:
         picard_metrics="results/picard/crosscheck/metrics.txt",
         picard_matrix="results/picard/crosscheck/matrix.txt",
         conpair=expand(
-            "results/conpair/{t}__{n}/concordance.tsv",
-            t=[p[0] for p in tn_pairs()],
-            n=[p[1] for p in tn_pairs()]
+            "results/conpair/{a}__{b}/concordance.tsv",
+            zip,
+            a=[x["samples"][0] for x in config.get("expected", []) if x["relationship"] == "tumor_normal"],
+            b=[x["samples"][1] for x in config.get("expected", []) if x["relationship"] == "tumor_normal"],
         ),
     output:
         tsv="results/relatedness_qc/relatedness_summary.tsv",
         html="results/relatedness_qc/relatedness_report.html"
     params:
         cfg="config/relatedness.yaml"
-    conda: "../envs/relatedness_report_v0.1.yaml"
+    conda: "../envs/report.yaml"
     script:
         "../scripts/relatedness_report.py"
 
-rule produce_relatedness:  # TARGET:  produce relatedness
-    """
-    Convenience entry point — call this rule to build the full relatedness
-    report and all required intermediate outputs.
-    """
+
+rule produce_relatedness:
     input:
         "results/relatedness_qc/relatedness_summary.tsv",
         "results/relatedness_qc/relatedness_report.html"

--- a/workflow/scripts/relatedness_report.py
+++ b/workflow/scripts/relatedness_report.py
@@ -1,0 +1,265 @@
+import os
+import yaml
+import pandas as pd
+import numpy as np
+from jinja2 import Template
+
+som_pairs = snakemake.input.som_pairs
+som_groups = snakemake.input.som_groups
+picard_metrics = snakemake.input.picard_metrics
+picard_matrix = snakemake.input.picard_matrix
+conpair_files = snakemake.input.get("conpair", [])
+out_tsv = snakemake.output.tsv
+out_html = snakemake.output.html
+cfg_path = snakemake.params.cfg
+
+with open(cfg_path, encoding="utf-8") as handle:
+    CFG = yaml.safe_load(handle)
+
+
+sp = pd.read_csv(som_pairs, sep="\t")
+sp_cols = {column.lower(): column for column in sp.columns}
+
+
+def sp_col(name):
+    return sp_cols.get(name, name)
+
+
+def pair_key(sample_a, sample_b):
+    return tuple(sorted([sample_a, sample_b]))
+
+
+sp["pair_key"] = [
+    pair_key(a, b)
+    for a, b in zip(sp[sp_col("sample_a")], sp[sp_col("sample_b")])
+]
+sp_pairs = {key: row for key, row in sp.set_index("pair_key").iterrows()}
+
+
+pm = pd.read_csv(picard_metrics, sep="\t", comment="#")
+
+path2sample = {}
+for sample, entry in CFG["samples"].items():
+    path = entry.get("bam") or entry.get("vcf")
+    if path:
+        path2sample[os.path.abspath(path)] = sample
+
+
+def file_to_sample(path):
+    absolute = os.path.abspath(path)
+    if absolute in path2sample:
+        return path2sample[absolute]
+    basename = os.path.basename(absolute)
+    for candidate, sample in path2sample.items():
+        if os.path.basename(candidate) == basename:
+            return sample
+    return basename
+
+
+pm["left_samp"] = pm["LEFT_FILE"].map(file_to_sample)
+pm["right_samp"] = pm["RIGHT_FILE"].map(file_to_sample)
+pm["pair_key"] = [
+    pair_key(a, b) for a, b in zip(pm["left_samp"], pm["right_samp"])
+]
+pm_best = pm.loc[pm.groupby("pair_key")["LOD_SCORE"].apply(lambda series: series.abs().idxmax())]
+picard_pairs = {key: row for key, row in pm_best.set_index("pair_key").iterrows()}
+
+
+conpair_frames = []
+for file_path in conpair_files:
+    if not os.path.exists(file_path):
+        continue
+    try:
+        frame = pd.read_csv(file_path, sep="\t")
+    except Exception:
+        frame = pd.read_csv(file_path)
+    frame.columns = [column.lower() for column in frame.columns]
+    pair = os.path.basename(os.path.dirname(file_path)).split("__")
+    if len(pair) == 2:
+        frame["sample_a"], frame["sample_b"] = pair
+    conpair_frames.append(frame)
+
+if conpair_frames:
+    con_df = pd.concat(conpair_frames, ignore_index=True)
+else:
+    con_df = pd.DataFrame()
+
+
+THRESH = {
+    "identical_relatedness": 0.95,
+    "tn_relatedness": 0.70,
+    "first_degree_relatedness": 0.45,
+    "ibs0_parent_child": 0,
+    "picard_mismatch_lod": -5.0,
+    "picard_match_lod": 5.0,
+}
+
+
+def get_somalier(sample_a, sample_b, field):
+    row = sp_pairs.get(pair_key(sample_a, sample_b))
+    if row is None:
+        return None
+    return row.get(field, row.get(field.upper()))
+
+
+def get_picard(sample_a, sample_b):
+    row = picard_pairs.get(pair_key(sample_a, sample_b))
+    if row is None:
+        return None
+    return {
+        "result": row.get("RESULT", ""),
+        "lod": float(row.get("LOD_SCORE", np.nan)),
+    }
+
+
+rows = []
+for expectation in CFG.get("expected", []):
+    relationship = expectation["relationship"]
+    sample_a, sample_b = expectation["samples"]
+    note = expectation.get("note", "")
+
+    som_rel = get_somalier(sample_a, sample_b, "relatedness")
+    ibs0 = get_somalier(sample_a, sample_b, "ibs0")
+    picard_info = get_picard(sample_a, sample_b)
+
+    status = "PASS"
+    reasons = []
+
+    if relationship in ("identical", "duplicate"):
+        if som_rel is not None and som_rel < THRESH["identical_relatedness"]:
+            status = "FAIL"
+            reasons.append(
+                f"Somalier.relatedness={som_rel:.3f} < {THRESH['identical_relatedness']}"
+            )
+        if picard_info is not None and picard_info["lod"] < THRESH["picard_match_lod"]:
+            status = "FAIL"
+            reasons.append(
+                f"Picard.LOD={picard_info['lod']:.1f} < {THRESH['picard_match_lod']}"
+            )
+    elif relationship == "tumor_normal":
+        if som_rel is not None and som_rel < THRESH["tn_relatedness"]:
+            status = "FAIL"
+            reasons.append(
+                f"Somalier.relatedness={som_rel:.3f} < {THRESH['tn_relatedness']}"
+            )
+        if picard_info is not None and picard_info["lod"] <= THRESH["picard_mismatch_lod"]:
+            status = "FAIL"
+            reasons.append(
+                f"Picard.LOD strongly negative ({picard_info['lod']:.1f})"
+            )
+    elif relationship in ("parent_child", "parent-offspring"):
+        if som_rel is not None and som_rel < THRESH["first_degree_relatedness"]:
+            status = "FAIL"
+            reasons.append(
+                f"Somalier.relatedness={som_rel:.3f} < {THRESH['first_degree_relatedness']}"
+            )
+        if ibs0 is not None and ibs0 > 2:
+            status = "FAIL"
+            reasons.append(f"Somalier.IBS0={ibs0} > 2 (expected ~0)")
+    elif relationship == "siblings":
+        if som_rel is not None and som_rel < THRESH["first_degree_relatedness"]:
+            status = "FAIL"
+            reasons.append(
+                f"Somalier.relatedness={som_rel:.3f} < {THRESH['first_degree_relatedness']}"
+            )
+        if ibs0 is not None and ibs0 <= 0:
+            status = "FAIL"
+            reasons.append(
+                f"Somalier.IBS0={ibs0} <= 0 (siblings typically >0)"
+            )
+    elif relationship == "unrelated":
+        if som_rel is not None and som_rel >= 0.2:
+            status = "FAIL"
+            reasons.append(
+                f"Somalier.relatedness={som_rel:.3f} unexpectedly high for unrelated"
+            )
+        if picard_info is not None and picard_info["lod"] >= THRESH["picard_match_lod"]:
+            status = "FAIL"
+            reasons.append(
+                f"Picard.LOD={picard_info['lod']:.1f} unexpectedly high for unrelated"
+            )
+    else:
+        reasons.append(f"Unknown relationship: {relationship}")
+
+    rows.append(
+        {
+            "sample_a": sample_a,
+            "sample_b": sample_b,
+            "relationship": relationship,
+            "note": note,
+            "somalier_relatedness": som_rel,
+            "somalier_ibs0": ibs0,
+            "picard_result": None if picard_info is None else picard_info["result"],
+            "picard_lod": None if picard_info is None else picard_info["lod"],
+            "status": status,
+            "reason": "; ".join(reasons) if reasons else "",
+        }
+    )
+
+summary = pd.DataFrame(rows).sort_values(
+    ["status", "relationship", "sample_a", "sample_b"]
+)
+os.makedirs(os.path.dirname(out_tsv), exist_ok=True)
+summary.to_csv(out_tsv, sep="\t", index=False)
+
+
+template = Template(
+    """
+<!doctype html><html><head>
+<meta charset="utf-8"><title>Relatedness QC</title>
+<style>body{font-family:system-ui,Arial} table{border-collapse:collapse} td,th{border:1px solid #ccc;padding:6px 8px} .FAIL{background:#ffe3e3} .PASS{background:#e6ffed}</style>
+</head><body>
+<h1>Relatedness QC</h1>
+<p><b>Samples:</b> {{ sample_count }} | <b>Somalier pairs:</b> {{ somalier_pairs }} | <b>Picard pairs:</b> {{ picard_pairs }}</p>
+<h2>Expectations</h2>
+<table>
+  <thead><tr>
+    <th>Status</th><th>Relationship</th><th>Sample A</th><th>Sample B</th>
+    <th>Somalier.relatedness</th><th>Somalier.IBS0</th><th>Picard.LOD</th><th>Notes / Reasons</th>
+  </tr></thead>
+  <tbody>
+  {% for row in rows %}
+  <tr class="{{ row.status }}">
+    <td>{{ row.status }}</td>
+    <td>{{ row.relationship }}</td>
+    <td>{{ row.sample_a }}</td>
+    <td>{{ row.sample_b }}</td>
+    <td>{{ "%.3f"|format(row.somalier_relatedness) if row.somalier_relatedness is not none else "" }}</td>
+    <td>{{ row.somalier_ibs0 if row.somalier_ibs0 is not none else "" }}</td>
+    <td>{{ "%.1f"|format(row.picard_lod) if row.picard_lod is not none else "" }}</td>
+    <td>{{ row.reason or row.note }}</td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+<h2>Files</h2>
+<ul>
+  <li>Somalier: <code>results/somalier/cohort_pairs.tsv</code>, <code>cohort_groups.tsv</code>, <code>cohort.html</code></li>
+  <li>Picard: <code>results/picard/crosscheck/metrics.txt</code>, <code>matrix.txt</code></li>
+  {% if has_conpair %}<li>Conpair per tumor/normal pair: <code>results/conpair/&lt;T&gt;__&lt;N&gt;/</code></li>{% endif %}
+  {% if peddy_enabled %}<li>Peddy: <code>results/peddy/peddy.html</code></li>{% endif %}
+</ul>
+
+<p style="margin-top:24px;font-size:90%"><b>Thresholds (heuristic defaults):</b>
+identical ≥ {{ thresholds.identical_relatedness }}, tumor-normal ≥ {{ thresholds.tn_relatedness }},
+first-degree ≥ {{ thresholds.first_degree_relatedness }},
+Picard match LOD ≥ {{ thresholds.picard_match_lod }}, strong mismatch LOD ≤ {{ thresholds.picard_mismatch_lod }}.
+</p>
+</body></html>
+"""
+)
+
+html = template.render(
+    rows=rows,
+    sample_count=len(CFG["samples"]),
+    somalier_pairs=len(sp),
+    picard_pairs=len(pm),
+    has_conpair=bool(conpair_files),
+    peddy_enabled=CFG.get("peddy", {}).get("enabled", False),
+    thresholds=THRESH,
+)
+
+os.makedirs(os.path.dirname(out_html), exist_ok=True)
+with open(out_html, "w", encoding="utf-8") as handle:
+    handle.write(html)


### PR DESCRIPTION
## Summary
- add an example relatedness configuration file and supporting conda environment definitions
- rework the relatedness_test_day rules to orchestrate Somalier, Picard, Conpair, optional Peddy, and the merged report
- add a reporting script that fuses metrics across tools and checks declared relationships

## Testing
- python -m compileall workflow/scripts/relatedness_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d613795a90833191fa6f5b601c9f76