### PR TITLE
Fix custom MultiQC sections and re-enable native relatedness modules

### DIFF
--- a/config/external_tools/multiqc_config.yaml
+++ b/config/external_tools/multiqc_config.yaml
@@ -51,6 +51,8 @@ module_order:
   - mosdepth
   - goleft_indexcov
   - sentieon
+  - peddy
+  - somalier
   - vcftools
   - kat
   - custom_content 
@@ -64,6 +66,7 @@ module_order:
   - relatedness
   - bcftools_variant_stats
   - rtg_vcfstats
+  - tiddit_sv
   - peddy_sample_qc
   - vep_annotation
   - snpeff_annotation
@@ -295,6 +298,14 @@ custom_data:
     plot_type: 'table'
     pconfig:
       id: 'rtg_vcfstats'
+  tiddit_sv:
+    id: 'tiddit_sv'
+    section_name: 'TIDDIT SV Summary'
+    description: 'Summary counts for selected TIDDIT structural variant VCFs'
+    file_format: 'tsv'
+    plot_type: 'table'
+    pconfig:
+      id: 'tiddit_sv'
   peddy_sample_qc:
     id: 'peddy_sample_qc'
     section_name: 'Peddy Sample QC'
@@ -390,6 +401,8 @@ sp:
     fn: "other_reports/bcftools_variant_stats_mqc.tsv"
   rtg_vcfstats:
     fn: "other_reports/rtg_vcfstats_mqc.tsv"
+  tiddit_sv:
+    fn: "other_reports/tiddit_sv_mqc.tsv"
   peddy_sample_qc:
     fn: "other_reports/peddy_sample_qc_mqc.tsv"
   vep_annotation:
@@ -402,8 +415,6 @@ sp:
     fn: "other_reports/alignstats_gs_mqc.tsv"
 
 exclude_modules:
-  - peddy
-  - somalier
   - slamdunk
   - adapterRemoval
   - rseqc

--- a/tests/test_multiqc_qc_targets.py
+++ b/tests/test_multiqc_qc_targets.py
@@ -88,6 +88,7 @@ def test_staged_multiqc_targets_and_dependencies_exist() -> None:
     assert "def _seq_data_component_inputs" in text
     assert "def _alignment_component_inputs" in text
     assert "def _variant_component_inputs" in text
+    assert "def _sv_component_inputs" in text
     assert 'qc_tool_enabled("fastp")' not in text
     assert "seqqc/fastp" not in text
     assert "qc_tool_enabled(\"fastv\", long_running=True)" in text
@@ -107,6 +108,7 @@ def test_staged_multiqc_targets_and_dependencies_exist() -> None:
         "relatedness_mqc.tsv",
         "bcftools_variant_stats_mqc.tsv",
         "rtg_vcfstats_mqc.tsv",
+        "tiddit_sv_mqc.tsv",
         "peddy_sample_qc_mqc.tsv",
         "expansionhunter_mqc.tsv",
         "vep_annotation_mqc.tsv",
@@ -177,8 +179,31 @@ def test_multiqc_custom_output_inventory_rules_exist() -> None:
         assert expected in script
 
 
+def test_multiqc_ignores_other_report_logs_and_custom_logs_avoid_mqc_suffix() -> None:
+    text = _read("workflow/rules/multiqc_final_wgs.smk")
+    htd = _read("workflow/rules/htd_calls.smk")
+
+    assert text.count('--ignore "*/other_reports/logs/*"') >= 4
+    assert text.count('--ignore "other_reports/logs/*"') >= 4
+    assert text.count('--ignore "*_mqc.log"') >= 4
+    assert text.count("workflow/scripts/multiqc_log_guard.py") >= 4
+    assert text.count("multiqc --version") >= 4
+    assert "docker://multiqc/multiqc:v1.35" in text
+    assert "daylilyinformatics/daylily_multiqc:0.2" not in text
+    assert "sequence_qc_outputs_custom_data.log" in text
+    assert "alignment_qc_outputs_custom_data.log" in text
+    assert "sequence_qc_outputs_mqc.log" not in text
+    assert "alignment_qc_outputs_mqc.log" not in text
+    assert "htd_calls_custom_data.log" in htd
+    for rule_file in (REPO_ROOT / "workflow/rules").glob("*.smk"):
+        rule_text = rule_file.read_text(encoding="utf-8")
+        assert "sequence_qc_outputs_mqc.log" not in rule_text, rule_file
+        assert "alignment_qc_outputs_mqc.log" not in rule_text, rule_file
+
+
 def test_contamination_and_relatedness_aggregates_are_wired() -> None:
     site_mix = _read("workflow/rules/site_mix_contam.smk")
+    contamination_script = _read("workflow/scripts/compile_contamination_mqc.py")
     relatedness = _read("workflow/rules/relatedness_batch.smk")
     report_script = _read("workflow/scripts/relatedness_report.py")
     report_env = _yaml("workflow/envs/report.yaml")
@@ -193,8 +218,10 @@ def test_contamination_and_relatedness_aggregates_are_wired() -> None:
         "site_mix_donor_mqc.tsv",
         "QC_CRAM_ALIGNERS",
         "qc_alignment_dedupers()",
-    ):
-        assert expected in site_mix
+            "workflow/scripts/compile_contamination_mqc.py",
+        ):
+            assert expected in site_mix
+    assert '"Sample",' in contamination_script
 
     for expected in (
         "rule relatedness_batch_manifest:",
@@ -237,12 +264,17 @@ def test_variant_qc_and_annotation_summaries_are_wired() -> None:
     peddy = _read("workflow/rules/peddy.smk")
     vep = _read("workflow/rules/vep.smk")
     snpeff = _read("workflow/rules/snpeff.smk")
+    tiddit = _read("workflow/rules/tiddit.smk")
     slurm_config = _yaml("config/day_profiles/slurm/templates/rule_config.yaml")
 
     assert "rule bcftools_variant_stats_gather:" in bcftools
     assert "bcftools_variant_stats_mqc.tsv" in bcftools
     assert "rule rtg_vcfstats_gather:" in rtg
     assert "rtg_vcfstats_mqc.tsv" in rtg
+    assert "rule tiddit_sv_mqc_gather:" in tiddit
+    assert "workflow/scripts/tiddit_sv_to_multiqc.py" in tiddit
+    assert "tiddit_sv_mqc.tsv" in tiddit
+    assert 'if "tiddit" not in sv_CALLERS:' in tiddit
     assert "rule peddy_sample_qc_gather:" in peddy
     assert "peddy_sample_qc_mqc.tsv" in peddy
     assert "rule vep:" not in vep
@@ -311,6 +343,7 @@ def test_multiqc_config_custom_content_entries() -> None:
         "relatedness",
         "bcftools_variant_stats",
         "rtg_vcfstats",
+        "tiddit_sv",
         "peddy_sample_qc",
         "vep_annotation",
         "snpeff_annotation",
@@ -324,8 +357,8 @@ def test_multiqc_config_custom_content_entries() -> None:
     assert "fastp" not in excludes
     assert "vep" not in excludes
     assert "snpeff" not in excludes
-    assert "peddy" in excludes
-    assert "somalier" in excludes
+    assert "peddy" not in excludes
+    assert "somalier" not in excludes
     assert "verifyBAMID" in excludes
     assert "sexdetermine" in excludes
 
@@ -367,8 +400,8 @@ def test_multiqc_sample_name_cleanup_contract() -> None:
 
     module_order = config["module_order"]
     assert len(module_order) == len(set(module_order))
-    assert "peddy" not in module_order
-    assert "somalier" not in module_order
+    assert "peddy" in module_order
+    assert "somalier" in module_order
     assert "peddy_sample_qc" in module_order
     assert "relatedness" in module_order
     assert "verifyBAMID" not in module_order
@@ -378,6 +411,7 @@ def test_multiqc_sample_name_cleanup_contract() -> None:
 def test_custom_multiqc_sample_ids_follow_pipeline_depth() -> None:
     common = _read("workflow/rules/common.smk")
     contamination = _read("workflow/rules/site_mix_contam.smk")
+    contamination_script = _read("workflow/scripts/compile_contamination_mqc.py")
     bcftools = _read("workflow/rules/bcftools_vcfstat.smk")
     rtg_vcfstats = _read("workflow/rules/rtg_vcfstats.smk")
     peddy = _read("workflow/rules/peddy.smk")
@@ -385,7 +419,8 @@ def test_custom_multiqc_sample_ids_follow_pipeline_depth() -> None:
     snpeff = _read("workflow/rules/snpeff.smk")
 
     assert "def day_stage_sample_id(sample, *components)" in common
-    assert "day_stage_sample_id(sample, aligner, deduper)" in contamination
+    assert "_stage_sample_id(sample, aligner, deduper)" in contamination_script
+    assert "compile_contamination_mqc.py" in contamination
     assert "day_stage_sample_id(sample, aligner, deduper, caller)" in bcftools
     assert "day_stage_sample_id(sample, aligner, deduper, caller)" in rtg_vcfstats
     assert "day_stage_sample_id(sample, aligner, deduper, caller)" in peddy

--- a/tests/test_multiqc_sample_identifiers.py
+++ b/tests/test_multiqc_sample_identifiers.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import csv
+import gzip
 import importlib.util
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -85,6 +87,9 @@ def test_custom_output_inventory_uses_stage_aware_sample_first_column(tmp_path: 
 def test_sequence_and_coverage_custom_tsv_contracts_are_sample_first() -> None:
     seqfu = _read("workflow/rules/seqfu.smk")
     coverage = _read("workflow/rules/calc_coverage_eveness.smk")
+    alignstats = _read("workflow/rules/alignstats.smk")
+    alignstats_compile = _read("workflow/rules/alignstats_compile.smk")
+    alignstats_compile_script = _read("workflow/scripts/compile_alignstats.py")
     multiqc_final = _read("workflow/rules/multiqc_final_wgs.smk")
     multiqc_cov_aln = _read("workflow/rules/multiqc_cov_aln.smk")
 
@@ -101,6 +106,45 @@ def test_sequence_and_coverage_custom_tsv_contracts_are_sample_first() -> None:
     assert "norm_cov_evenness_combo_mqc.tsv" in multiqc_cov_aln
     assert "normcovevenness_combo_mqc.tsv" not in coverage
     assert "normcovevenness_combo_mqc.tsv" not in multiqc_final
+    assert '"Sample", "base_sample", "aligner", "deduper"' in alignstats
+    assert "day_stage_sample_id(" in alignstats
+    assert "params.ddup" in alignstats
+    assert "workflow/scripts/compile_alignstats.py" in alignstats_compile
+    assert 'CORE_FIELDS = ["Sample", "base_sample", "aligner", "deduper"]' in alignstats_compile_script
+
+
+def test_alignstats_compile_normalizes_legacy_space_delimited_rows(
+    tmp_path: Path,
+) -> None:
+    module = _load_module(
+        REPO_ROOT / "workflow/scripts/compile_alignstats.py",
+        "compile_alignstats_under_test",
+    )
+    alignstats = (
+        tmp_path
+        / "results/day/hg38/HG003/align/sent/dmd/alignqc/alignstats/"
+        / "HG003.sent.dmd.alignstats.tsv"
+    )
+    alignstats.parent.mkdir(parents=True)
+    alignstats.write_text(
+        "sample aligner AlignedBases MappedReads\n"
+        "HG003.sent sent 12345 678\n",
+        encoding="utf-8",
+    )
+
+    fieldnames, rows = module.collect_rows(str(tmp_path / "results/day/hg38/"))
+
+    assert fieldnames[:4] == ["Sample", "base_sample", "aligner", "deduper"]
+    assert rows == [
+        {
+            "Sample": "HG003.sent.dmd",
+            "base_sample": "HG003",
+            "aligner": "sent",
+            "deduper": "dmd",
+            "AlignedBases": "12345",
+            "MappedReads": "678",
+        }
+    ]
 
 
 def test_variant_and_concordance_custom_tsvs_include_full_stage_identity() -> None:
@@ -111,6 +155,7 @@ def test_variant_and_concordance_custom_tsvs_include_full_stage_identity() -> No
     peddy = _read("workflow/rules/peddy.smk")
     concordance = _read("workflow/rules/rtg_vcfeval.smk")
     concordance_parser = _read("workflow/scripts/parse-vcfeval-summary.py")
+    tiddit = _read("workflow/rules/tiddit.smk")
 
     for text in (bcftools, rtg_vcfstats, snpeff, vep, peddy):
         assert '"Sample",' in text
@@ -129,6 +174,138 @@ def test_variant_and_concordance_custom_tsvs_include_full_stage_identity() -> No
     aggregate_rule = concordance[concordance.index("rule produce_snv_concordances:") :]
     assert "perl -pi" not in aggregate_rule
     assert "\n    conda:" not in aggregate_rule
+    assert "tiddit_sv_mqc.tsv" in tiddit
+    assert "tiddit_sv_to_multiqc.py" in tiddit
+
+
+def test_contamination_and_tiddit_custom_tsvs_are_sample_first(tmp_path: Path) -> None:
+    site_mix = _read("workflow/rules/site_mix_contam.smk")
+    contamination_script = _read("workflow/scripts/compile_contamination_mqc.py")
+    contamination_module = _load_module(
+        REPO_ROOT / "workflow/scripts/compile_contamination_mqc.py",
+        "compile_contamination_mqc_under_test",
+    )
+    tiddit_module = _load_module(
+        REPO_ROOT / "workflow/scripts/tiddit_sv_to_multiqc.py",
+        "tiddit_sv_to_multiqc_under_test",
+    )
+
+    assert "workflow/scripts/compile_contamination_mqc.py" in site_mix
+    assert "run:" not in site_mix[site_mix.index("rule contamination_mqc_gather:") :]
+    assert 'CONTAMINATION_FIELDS = [\n    "Sample",' in contamination_script
+    assert 'VB2_FIELDS = [\n    "Sample",' in contamination_script
+    assert 'DONOR_FIELDS = [\n    "Sample",' in contamination_script
+    assert '"Sample": sample_id' in contamination_script
+
+    vb2_path = (
+        tmp_path
+        / "results/day/hg38/HG003/align/sent/dmd/alignqc/contam/vb2/100k/"
+        / "HG003.sent.dmd.100k.vb2.tsv"
+    )
+    vb2_path.parent.mkdir(parents=True)
+    vb2_path.write_text(
+        "FREEMIX\t#SNPS\t#READS\tAVG_DP\n0.012\t100000\t200\t2\n",
+        encoding="utf-8",
+    )
+    bench_path = (
+        tmp_path
+        / "results/day/hg38/HG003/benchmarks/HG003.sent.dmd.100k.vb2.bench.tsv"
+    )
+    bench_path.parent.mkdir(parents=True)
+    bench_path.write_text("s\ttask_cost\n600\t0.1\n", encoding="utf-8")
+    gatk_path = (
+        tmp_path
+        / "results/day/hg38/HG003/align/sent/dmd/alignqc/contam/gatk/"
+        / "HG003.sent.dmd.gatk.tsv"
+    )
+    gatk_path.parent.mkdir(parents=True)
+    gatk_path.write_text("FREEMIX\n0.0\n", encoding="utf-8")
+    contam_out = tmp_path / "contamination_mqc.tsv"
+    vb2_out = tmp_path / "verifybamid2_panel_comparison_mqc.tsv"
+    site_out = tmp_path / "site_mix_contam_mqc.tsv"
+    donor_out = tmp_path / "site_mix_donor_mqc.tsv"
+
+    contamination_module.compile_reports(
+        SimpleNamespace(
+            sample_map_json='{"HG003":"EXT-HG003"}',
+            panel_metadata_json=(
+                '{"100k":{"label":"100k","snp_count":"100000",'
+                '"svd_prefix":"/fsx/data/verifybamid/100k"}}'
+            ),
+            contamination_output=str(contam_out),
+            vb2_comparison_output=str(vb2_out),
+            site_mix_output=str(site_out),
+            donor_output=str(donor_out),
+            vb2=[str(vb2_path)],
+            vb2_bench=[str(bench_path)],
+            gatk=[str(gatk_path)],
+            site_mix=[],
+            site_mix_donors=[],
+        )
+    )
+    with contam_out.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+        assert rows[0]["Sample"] == "HG003.sent.dmd"
+        assert rows[0]["external_sample_id"] == "EXT-HG003"
+    with vb2_out.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+        assert rows[0]["Sample"] == "HG003.sent.dmd"
+        assert rows[0]["panel_id"] == "100k"
+    for output in (site_out, donor_out):
+        assert output.read_text(encoding="utf-8").split("\t", 1)[0] == "Sample"
+
+    vcf_path = (
+        tmp_path
+        / "results/day/hg38/HG003/align/sent/dmd/sv/tiddit/"
+        / "HG003.sent.tiddit.sv.sort.vcf.gz"
+    )
+    vcf_path.parent.mkdir(parents=True)
+    with gzip.open(vcf_path, "wt", encoding="utf-8") as handle:
+        handle.write("##fileformat=VCFv4.2\n")
+        handle.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+        handle.write("chr1\t10\t.\tN\t<DEL>\t.\tPASS\tSVTYPE=DEL;END=20\n")
+        handle.write("chr1\t30\t.\tN\t<BND>\t.\tPASS\tSVTYPE=BND\n")
+        handle.write("chr1\t40\t.\tN\t<DUP>\t.\tPASS\tSVTYPE=DUP\n")
+        handle.write("chr1\t50\t.\tN\t<UNK>\t.\tPASS\tEND=55\n")
+
+    output = tmp_path / "tiddit_sv_mqc.tsv"
+    tiddit_module.write_summary([str(vcf_path)], str(output))
+    with output.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+
+    assert rows[0]["Sample"] == "HG003.sent.dmd.tiddit"
+    assert rows[0]["base_sample"] == "HG003"
+    assert rows[0]["aligner"] == "sent"
+    assert rows[0]["deduper"] == "dmd"
+    assert rows[0]["sv_caller"] == "tiddit"
+    assert rows[0]["total_records"] == "4"
+    assert rows[0]["DEL"] == "1"
+    assert rows[0]["DUP"] == "1"
+    assert rows[0]["BND"] == "1"
+    assert rows[0]["no_svtype"] == "1"
+    assert_valid_multiqc_sample_id(rows[0]["Sample"], requires_deduper=True)
+
+
+def test_multiqc_log_guard_renames_empty_logs_and_rejects_nonempty_logs(
+    tmp_path: Path,
+) -> None:
+    module = _load_module(
+        REPO_ROOT / "workflow/scripts/multiqc_log_guard.py",
+        "multiqc_log_guard_under_test",
+    )
+    log_dir = tmp_path / "other_reports/logs"
+    log_dir.mkdir(parents=True)
+    empty_log = log_dir / "sequence_qc_outputs_mqc.log"
+    empty_log.touch()
+
+    renamed = module.guard_log_dir(log_dir)
+
+    assert not empty_log.exists()
+    assert renamed == [log_dir / "sequence_qc_outputs_legacy_custom_data.log"]
+    bad_log = log_dir / "alignment_qc_outputs_mqc.log"
+    bad_log.write_text("metric\tvalue\n", encoding="utf-8")
+    with pytest.raises(SystemExit, match="non-empty \\*_mqc.log"):
+        module.guard_log_dir(log_dir)
 
 
 def test_rtg_vcfeval_requests_explicit_memory() -> None:
@@ -142,10 +319,10 @@ def test_native_multiqc_collision_modules_are_excluded_and_cleaned() -> None:
     multiqc = _read("config/external_tools/multiqc_config.yaml")
     picard = _read("workflow/rules/picard.smk")
 
-    assert "\n  - peddy\n" in multiqc[multiqc.index("exclude_modules:") :]
-    assert "\n  - somalier\n" in multiqc[multiqc.index("exclude_modules:") :]
-    assert "\n  - peddy\n" not in multiqc[multiqc.index("module_order:") : multiqc.index("table_columns_visible:")]
-    assert "\n  - somalier\n" not in multiqc[multiqc.index("module_order:") : multiqc.index("table_columns_visible:")]
+    assert "\n  - peddy\n" not in multiqc[multiqc.index("exclude_modules:") :]
+    assert "\n  - somalier\n" not in multiqc[multiqc.index("exclude_modules:") :]
+    assert "\n  - peddy\n" in multiqc[multiqc.index("module_order:") : multiqc.index("table_columns_visible:")]
+    assert "\n  - somalier\n" in multiqc[multiqc.index("module_order:") : multiqc.index("table_columns_visible:")]
     assert 'peddy/background_pca:' not in multiqc
     assert r"^(.*)-([A-Za-z0-9_]+)-(dmd|smd|spmd|na)-cram$" in multiqc
     assert r"\.metrics$" in multiqc

--- a/workflow/rules/alignstats.smk
+++ b/workflow/rules/alignstats.smk
@@ -100,6 +100,7 @@ rule finish_align_stats:
         n=config["alignstats"]["num_reads_in_mem"],
         cluster_sample=ret_sample,
         alnr_f=fetch_alnr,
+        ddup=lambda wildcards: wildcards.ddup,
         ld_preload=" "
         if "ld_preload" not in config["malloc_alt"]
         else config["malloc_alt"]["ld_preload"],
@@ -107,14 +108,22 @@ rule finish_align_stats:
         if "ld_preload" not in config["alignstats"]
         else config["alignstats"]["ld_preload"],
     run:
-        import os
-        import sys
+        import csv
         import json
 
         j = json.load(open(f"{input.json}", "r"))
-        aa = "sample\taligner\t" + "\t".join([str(x) for x in sorted(j)])
-        bb = f"{params.cluster_sample}.{params.alnr_f}\t{params.alnr_f}\t" + "\t".join(
-            [str(j[x]) for x in sorted(j)]
-        )
-        os.system(f"echo {aa} > {output.tsv} ; echo {bb} >> {output.tsv}")
-
+        metric_fields = [str(x) for x in sorted(j)]
+        fieldnames = ["Sample", "base_sample", "aligner", "deduper"] + metric_fields
+        row = {
+            "Sample": day_stage_sample_id(
+                params.cluster_sample, params.alnr_f, params.ddup
+            ),
+            "base_sample": params.cluster_sample,
+            "aligner": params.alnr_f,
+            "deduper": params.ddup,
+        }
+        row.update({field: str(j[field]) for field in metric_fields})
+        with open(output.tsv, "w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+            writer.writeheader()
+            writer.writerow(row)

--- a/workflow/rules/alignstats_compile.smk
+++ b/workflow/rules/alignstats_compile.smk
@@ -54,18 +54,17 @@ rule alignstats_compile:
         cluster_sample="na",
     log:
         MDIR + "logs/alignstats_summary_compile.log",
-    conda:
-        config["alignstats"]["env_yaml"]
     shell:
-        "(mkdir -p {MDIR}logs/as;"
-        "echo STARTcompileAstats > {log};"
-        "find {MDIR}*/align/*/*/alignqc/alignstats/*alignstats.tsv | head -n 1 | parallel -j 1 'head -n 1 {params.l}{params.r} > {output[0]}; echo a_{params.l}{params.r} >> {log}' >> {log} 2>&1; "
-        "find {MDIR}*/align/*/*/alignqc/alignstats/*alignstats.tsv | parallel -j 1 'tail -n 1 {params.l}{params.r} >> {output[0]}; echo b_{params.l}{params.r}  >> {log} ' >> {log} 2>&1;  "
-        "cp {output[0]} {output[1]};"
-        "cp {output[0]} {output[2]};" #         "perl -pi -e 's/_DBC0_0//g;' {output};"
-        ") || touch logs/ALIGNSTATSCOMPIEFAILEDw_$? ; "
-        "perl -pi -e 's/ /\t/g;' {output[2]};"
-        "cp {output[2]} {output[3]};"
+        """
+        set -euo pipefail
+        python workflow/scripts/compile_alignstats.py \
+          --mdir {MDIR:q} \
+          --log {log:q} \
+          --bsummary {output[0]:q} \
+          --csummary {output[1]:q} \
+          --combo {output[2]:q} \
+          --generalstats {output[3]:q}
+        """
 
 
 localrules:

--- a/workflow/rules/expansionhunter.smk
+++ b/workflow/rules/expansionhunter.smk
@@ -290,12 +290,14 @@ rule expansionhunter_multiqc:
         gtag=config["gittag"],
         cluster_sample="expansionhunter_multiqc",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
         """
         set -euo pipefail
         mkdir -p $(dirname {output.html:q}) $(dirname {log:q})
         : > {log:q}
+        python workflow/scripts/multiqc_log_guard.py --log-dir {MDIR:q}other_reports/logs >> {log:q} 2>&1
+        multiqc --version >> {log:q} 2>&1 || true
         multiqc --interactive -m custom_content -f \
           --config {input.config:q} \
           --filename $(basename {output.html:q}) \

--- a/workflow/rules/htd_calls.smk
+++ b/workflow/rules/htd_calls.smk
@@ -90,7 +90,7 @@ rule htd_calls_mqc:
     output:
         MDIR + "other_reports/htd_calls_mqc.tsv"
     log:
-        MDIR + "other_reports/logs/htd_calls_mqc.log"
+        MDIR + "other_reports/logs/htd_calls_custom_data.log"
     container: None
     shell:
         """

--- a/workflow/rules/multiqc_cov_aln.smk
+++ b/workflow/rules/multiqc_cov_aln.smk
@@ -27,9 +27,9 @@ rule multiqc_cov_aln:  # TARGET : Run Alignment and Generate Alignment and Cover
         gbranch=config["gitbranch"],
         cluster_sample=f"{RU[0]}_{EX[0]}",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
-        "(multiqc --interactive -x '*.js' -x '*bench.tsv' -x '*.bam' -x '*.fastq.gz' -x '*multiqc*' -x '*pyc' -x '*.fastq.gz'  -x  '*impute*glm*' -f -i 'SEQQC / COVERAGE & ALIGNMENT REPORT' -p  -b '{RU[0]}_{EX[0]} ___ {params.gbranch} {params.gtag} {params.ghash}' --sample-filters config/external_tools/multiqc_samplebtn_lcwgs.tsv -n {params.fn} -o {params.odir} --profile-runtime -c {params.micro_cfg} -c {params.macro_cfg} {MDIR}) || (echo 'Multiqc Exited With: '$? && time sleep 1 && echo done) "
+        "(multiqc --version > {log} 2>&1 || true; multiqc --interactive -x '*.js' -x '*bench.tsv' -x '*.bam' -x '*.fastq.gz' -x '*multiqc*' -x '*pyc' -x '*.fastq.gz'  -x  '*impute*glm*' -f -i 'SEQQC / COVERAGE & ALIGNMENT REPORT' -p  -b '{RU[0]}_{EX[0]} ___ {params.gbranch} {params.gtag} {params.ghash}' --sample-filters config/external_tools/multiqc_samplebtn_lcwgs.tsv -n {params.fn} -o {params.odir} --profile-runtime -c {params.micro_cfg} -c {params.macro_cfg} {MDIR} >> {log} 2>&1) || (echo 'Multiqc Exited With: '$? && time sleep 1 && echo done) "
 
 
 localrules:

--- a/workflow/rules/multiqc_final_wgs.smk
+++ b/workflow/rules/multiqc_final_wgs.smk
@@ -151,6 +151,7 @@ def _variant_component_inputs(wildcards):
     pairs = valid_snv_alnr_pairs(ALL_ALIGNERS, snv_CALLERS)
     paths.append(MDIR + "other_reports/bcftools_variant_stats_mqc.tsv")
     paths.append(MDIR + "other_reports/rtg_vcfstats_mqc.tsv")
+    paths.extend(_sv_component_inputs(wildcards))
     if qc_tool_enabled("peddy"):
         paths.extend(["logs/peddy_gathered.done", MDIR + "other_reports/peddy_sample_qc_mqc.tsv"])
     if qc_tool_enabled("expansionhunter") and set(ALIGNERS) & EXPANSIONHUNTER_ALIGNERS:
@@ -163,6 +164,13 @@ def _variant_component_inputs(wildcards):
         paths.append(MDIR + "other_reports/htd_calls_mqc.tsv")
     if len(CONCORDANCE_SAMPLES.keys()) > 0 and pairs:
         paths.append(MDIR + "other_reports/giab_concordance_mqc.tsv")
+    return paths
+
+
+def _sv_component_inputs(wildcards):
+    paths = []
+    if "tiddit" in sv_CALLERS:
+        paths.append(MDIR + "other_reports/tiddit_sv_mqc.tsv")
     return paths
 
 
@@ -230,7 +238,7 @@ rule sequence_qc_outputs_custom_data:
     output:
         MDIR + "other_reports/sequence_qc_outputs_mqc.tsv"
     log:
-        MDIR + "other_reports/logs/sequence_qc_outputs_mqc.log"
+        MDIR + "other_reports/logs/sequence_qc_outputs_custom_data.log"
     container: None
     shell:
         """
@@ -249,7 +257,7 @@ rule alignment_qc_outputs_custom_data:
     output:
         MDIR + "other_reports/alignment_qc_outputs_mqc.tsv"
     log:
-        MDIR + "other_reports/logs/alignment_qc_outputs_mqc.log"
+        MDIR + "other_reports/logs/alignment_qc_outputs_custom_data.log"
     container: None
     shell:
         """
@@ -291,14 +299,19 @@ rule multiqc_seq_data:  # TARGET: sequence-data QC MultiQC report
         gtag=config["gittag"],
         cluster_sample="multiqc_seq_data",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
         """
         set -euo pipefail
         mkdir -p $(dirname {output:q}) $(dirname {log:q})
+        python workflow/scripts/multiqc_log_guard.py --log-dir {MDIR:q}other_reports/logs > {log:q} 2>&1
+        multiqc --version >> {log:q} 2>&1 || true
         multiqc -f \
           --config ./config/external_tools/multiqc_config.yaml \
           --custom-css-file ./config/external_tools/multiqc.css \
+          --ignore "*/other_reports/logs/*" \
+          --ignore "other_reports/logs/*" \
+          --ignore "*_mqc.log" \
           --template default \
           --filename {output:q} \
           -i 'Sequence Data MultiQC Report' \
@@ -326,14 +339,19 @@ rule multiqc_alignment:  # TARGET: sequence plus alignment QC MultiQC report
         gtag=config["gittag"],
         cluster_sample="multiqc_alignment",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
         """
         set -euo pipefail
         mkdir -p $(dirname {output:q}) $(dirname {log:q})
+        python workflow/scripts/multiqc_log_guard.py --log-dir {MDIR:q}other_reports/logs > {log:q} 2>&1
+        multiqc --version >> {log:q} 2>&1 || true
         multiqc -f \
           --config ./config/external_tools/multiqc_config.yaml \
           --custom-css-file ./config/external_tools/multiqc.css \
+          --ignore "*/other_reports/logs/*" \
+          --ignore "other_reports/logs/*" \
+          --ignore "*_mqc.log" \
           --template default \
           --filename {output:q} \
           -i 'Alignment MultiQC Report' \
@@ -361,14 +379,19 @@ rule multiqc_variants:  # TARGET: sequence, alignment, and variant QC MultiQC re
         gtag=config["gittag"],
         cluster_sample="multiqc_variants",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
         """
         set -euo pipefail
         mkdir -p $(dirname {output:q}) $(dirname {log:q})
+        python workflow/scripts/multiqc_log_guard.py --log-dir {MDIR:q}other_reports/logs > {log:q} 2>&1
+        multiqc --version >> {log:q} 2>&1 || true
         multiqc -f \
           --config ./config/external_tools/multiqc_config.yaml \
           --custom-css-file ./config/external_tools/multiqc.css \
+          --ignore "*/other_reports/logs/*" \
+          --ignore "other_reports/logs/*" \
+          --ignore "*_mqc.log" \
           --template default \
           --filename {output:q} \
           -i 'Variant QC MultiQC Report' \
@@ -402,11 +425,13 @@ rule multiqc_final_wgs:  # TARGET: the big report
     log:
         f"{MDIR}reports/logs/all__mqc_fin_a.log",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
         """
         dbill='$';
         mkdir -p $(dirname {output.html:q}) $(dirname {log:q})
+        python workflow/scripts/multiqc_log_guard.py --log-dir {MDIR:q}other_reports/logs > {log:q} 2>&1
+        multiqc --version >> {log:q} 2>&1 || true
         echo '''
 report_header_info:
   - Project/Budget: "REGSUB_PROJECT"
@@ -438,6 +463,9 @@ report_header_info:
         --config {output.header:q} \
         --config ./config/external_tools/multiqc_config.yaml  \
         --custom-css-file ./config/external_tools/multiqc.css \
+        --ignore "*/other_reports/logs/*" \
+        --ignore "other_reports/logs/*" \
+        --ignore "*_mqc.log" \
         --ignore "*/norm_cov_eveness/*" \
         --ignore "*sort_metrics/*" \
         --template default \

--- a/workflow/rules/multiqc_for_bcl2fq.smk
+++ b/workflow/rules/multiqc_for_bcl2fq.smk
@@ -109,11 +109,12 @@ rule multiqc_bcl2fq:
         cluster_sample="bcl2fqMQC_{config['b2fq_ruid']}",
         iop_d="results/bcl2fq_reports/"+config["b2fq_ruid"],
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
        """
        (ln -s {params.rud} results/bcl2fq_reports/{params.ru}) ;
        (mkdir -p $(dirname {output.interop1}) ) ;
+       multiqc --version > {log} 2>&1 || true ;
        ### export LD_LIBRARY_PATH=./resources/lib/ &&
        mkdir -p {params.interop_d};
        ### export LD_LIBRARY_PATH=./resources/lib/ && interop_summary {params.iop_d} --csv=1 > {output.interop1};
@@ -123,7 +124,7 @@ rule multiqc_bcl2fq:
         ### export LD_LIBRARY_PATH=./resources/lib/ && interop_plot_by_lane  {params.iop_d} | perl -pe "s/(output \')(.*)(\.png)/\$1{params.odir2}\$2\$3_mqc\.png/g" | gnuplot;
         ### export LD_LIBRARY_PATH=./resources/lib/ && interop_plot_qscore_histogram  {params.iop_d} | perl -pe "s/(output \')(.*)(\.png)/\$1{params.odir2}\$2\$3_mqc\.png/g" | gnuplot;
        ### export LD_LIBRARY_PATH=./resources/lib/ && interop_plot_qscore_heatmap  {params.iop_d}| perl -pe "s/(output \')(.*)(\.png)/\$1{params.odir2}\$2\$3_mqc\.png/g" | gnuplot;
-       multiqc --interactive -m custom_content  -m interop -m bcl2fastq -x '*/mod/*' -x '*.js' -x '*.bam' -x '*.fastq.gz' -x '*multiqc*' -x '*pyc' -x '*.fastq.gz' -v -x '*/impute/*'  -i '{params.ru} BCL2FQ/Interop REPORT' -p  -b '{params.ru} ___ {params.gbranch} {params.gtag} {params.ghash}' -n {params.fn} -o {params.odir} --profile-runtime  -c {params.macro_cfg} -f results/ ;
+       multiqc --interactive -m custom_content  -m interop -m bcl2fastq -x '*/mod/*' -x '*.js' -x '*.bam' -x '*.fastq.gz' -x '*multiqc*' -x '*pyc' -x '*.fastq.gz' -v -x '*/impute/*'  -i '{params.ru} BCL2FQ/Interop REPORT' -p  -b '{params.ru} ___ {params.gbranch} {params.gtag} {params.ghash}' -n {params.fn} -o {params.odir} --profile-runtime  -c {params.macro_cfg} -f results/ >> {log} 2>&1 ;
         touch {params.mdir}benchmarks/bcl2fq_{params.ru}_multiqc.bench.tsv ;
         ls {output}; """
         # in lieu of the command line latency wait

--- a/workflow/rules/multiqc_for_raw_fastqs.smk
+++ b/workflow/rules/multiqc_for_raw_fastqs.smk
@@ -31,13 +31,14 @@ rule multiqc_for_raw_fastqs:
     log:
         f"{MDIR}logs/multiqc/SEQQC_multiqc.FQ.log",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
         """
 
 
         dbill='$';
         cp ./config/external_tools/multiqc_header.yaml ./$(dirname {output})/rfq_multiqc_header.yaml;
+        multiqc --version > {log} 2>&1 || true
 
         multiqc -f  \
         --config   ./$(dirname {output})/rfq_multiqc_header.yaml \
@@ -47,7 +48,7 @@ rule multiqc_for_raw_fastqs:
         --filename {output} \
         -i 'FASTQ Multiqc Report' \
         -b 'https://github.com/Daylily-Informatics/daylily-omics-analysis (BRANCH:{params.gbranch}) (TAG:{params.gtag}) (HASH:{params.ghash}) ' \
-        $(dirname {input} )/../ > {log} 2>&1;
+        $(dirname {input} )/../ >> {log} 2>&1;
         ls -lt {output};
 
         """

--- a/workflow/rules/multiqc_singleton.smk
+++ b/workflow/rules/multiqc_singleton.smk
@@ -51,10 +51,13 @@ rule multiqc_singleton:  # TARGET: the big report
     log:
         f"{MDIR}reports/logs/all__mqc_fin_a2.log",
     container:
-        "docker://daylilyinformatics/daylily_multiqc:0.2"
+        "docker://multiqc/multiqc:v1.35"
     shell:
         """
         dbill='$';
+        mkdir -p $(dirname {output[0]}) $(dirname {log})
+        python workflow/scripts/multiqc_log_guard.py --log-dir {MDIR}other_reports/logs > {log} 2>&1
+        multiqc --version >> {log} 2>&1 || true
 
         echo '''
 report_header_info:
@@ -89,6 +92,9 @@ report_header_info:
         --custom-css-file ./config/external_tools/multiqc.css \
         --template default \
         --ignore "*sort_metrics/*" \
+        --ignore "*/other_reports/logs/*" \
+        --ignore "other_reports/logs/*" \
+        --ignore "*_mqc.log" \
         --ignore "*/norm_cov_eveness/*" \
         --filename {output[0]} \
         -i '{params.rtitle} Multiqc Report' \

--- a/workflow/rules/site_mix_contam.smk
+++ b/workflow/rules/site_mix_contam.smk
@@ -3,6 +3,7 @@
 # - Optional donor attribution uses a candidate BAM/CRAM/VCF manifest.
 
 import csv
+import json
 import os
 
 
@@ -131,6 +132,28 @@ def _seconds_to_minutes(value):
     except (TypeError, ValueError):
         return ""
 
+
+def _sample_external_ids_json(wildcards=None):
+    sample_info = config.get("sample_info", {})
+    return json.dumps(
+        {
+            sample: str(sample_info.get(sample, {}).get("external_sample_id", sample))
+            for sample in SSAMPS
+        }
+    )
+
+
+def _verifybamid2_panel_metadata_json(wildcards=None):
+    metadata = {}
+    for panel_id in VERIFYBAMID2_PANELS:
+        panel_cfg = _verifybamid2_panel_config(panel_id)
+        metadata[panel_id] = {
+            "label": str(panel_cfg.get("label", panel_id)),
+            "snp_count": str(panel_cfg.get("snp_count", "")),
+            "svd_prefix": _supporting_file_name(panel_cfg.get("svd_prefix", "")),
+        }
+    return json.dumps(metadata)
+
 rule site_mix_contam:
     input:
         pileups = MDIR + "{sample}/align/{alnr}/{ddup}/alignqc/contam/gatk/{sample}.{alnr}.{ddup}.pileups.table",
@@ -207,234 +230,29 @@ rule contamination_mqc_gather:
         vb2_comparison=MDIR + "other_reports/verifybamid2_panel_comparison_mqc.tsv",
         site_mix=MDIR + "other_reports/site_mix_contam_mqc.tsv",
         donors=MDIR + "other_reports/site_mix_donor_mqc.tsv",
-    run:
-        os.makedirs(os.path.dirname(str(output.contamination)), exist_ok=True)
-        contamination_fields = [
-            "sample_id",
-            "external_sample_id",
-            "aligner",
-            "deduper",
-            "panel_id",
-            "panel_label",
-            "tool",
-            "method",
-            "contamination_fraction",
-            "contamination_pct",
-            "ci_low_fraction",
-            "ci_high_fraction",
-            "unknown_contamination_fraction",
-            "unknown_contamination_pct",
-            "site_count",
-            "read_count",
-            "mean_depth",
-            "svd_prefix",
-            "source_path",
-            "status",
-        ]
-        vb2_fields = [
-            "sample_id",
-            "external_sample_id",
-            "aligner",
-            "deduper",
-            "panel_id",
-            "panel_label",
-            "snp_count",
-            "svd_prefix",
-            "freemix_fraction",
-            "contamination_pct",
-            "site_count",
-            "read_count",
-            "mean_depth",
-            "runtime_seconds",
-            "runtime_minutes",
-            "task_cost",
-            "source_path",
-            "benchmark_path",
-            "status",
-        ]
-        donor_fields = [
-            "sample_id",
-            "external_sample_id",
-            "aligner",
-            "deduper",
-            "source_rank",
-            "source_sample_id",
-            "is_unknown_source",
-            "contamination_fraction",
-            "contamination_pct",
-            "single_source_delta_log_likelihood",
-            "source_path",
-        ]
-        with open(output.contamination, "w", newline="") as contam_handle, open(
-            output.site_mix, "w", newline=""
-        ) as site_handle, open(output.vb2_comparison, "w", newline="") as vb2_handle:
-            contam_writer = csv.DictWriter(
-                contam_handle, fieldnames=contamination_fields, delimiter="\t"
-            )
-            site_writer = csv.DictWriter(
-                site_handle, fieldnames=contamination_fields, delimiter="\t"
-            )
-            vb2_writer = csv.DictWriter(
-                vb2_handle, fieldnames=vb2_fields, delimiter="\t"
-            )
-            contam_writer.writeheader()
-            site_writer.writeheader()
-            vb2_writer.writeheader()
-            vb2_benchmarks = _benchmark_by_vb2_key(input.vb2_bench)
-            for path in input.vb2:
-                sample, external, aligner, deduper, panel_id = _parse_vb2_panel_path(path)
-                sample_id = day_stage_sample_id(sample, aligner, deduper)
-                with open(path, newline="") as handle:
-                    rows = list(csv.DictReader(handle, delimiter="\t"))
-                row = rows[0] if rows else {}
-                freemix = row.get("FREEMIX", "")
-                panel_cfg = _verifybamid2_panel_config(panel_id)
-                benchmark_path = vb2_benchmarks.get((sample, aligner, deduper, panel_id), "")
-                benchmark = _read_benchmark_row(benchmark_path)
-                runtime_seconds = benchmark.get("s", "")
-                panel_label = str(panel_cfg.get("label", panel_id))
-                snp_count = str(panel_cfg.get("snp_count", row.get("#SNPS", "")))
-                svd_prefix = _supporting_file_name(panel_cfg["svd_prefix"])
-                contam_row = {
-                    "sample_id": sample_id,
-                    "external_sample_id": external,
-                    "aligner": aligner,
-                    "deduper": deduper,
-                    "panel_id": panel_id,
-                    "panel_label": panel_label,
-                    "tool": "verifybamid2",
-                    "method": "freemix",
-                    "contamination_fraction": freemix,
-                    "contamination_pct": _safe_pct(freemix),
-                    "ci_low_fraction": "",
-                    "ci_high_fraction": "",
-                    "unknown_contamination_fraction": "",
-                    "unknown_contamination_pct": "",
-                    "site_count": row.get("#SNPS", snp_count),
-                    "read_count": row.get("#READS", ""),
-                    "mean_depth": row.get("AVG_DP", ""),
-                    "svd_prefix": svd_prefix,
-                    "source_path": path,
-                    "status": "ok" if freemix not in ["", "NA"] else "no_call",
-                }
-                contam_writer.writerow(contam_row)
-                vb2_writer.writerow(
-                    {
-                        "sample_id": sample_id,
-                        "external_sample_id": external,
-                        "aligner": aligner,
-                        "deduper": deduper,
-                        "panel_id": panel_id,
-                        "panel_label": panel_label,
-                        "snp_count": snp_count,
-                        "svd_prefix": svd_prefix,
-                        "freemix_fraction": freemix,
-                        "contamination_pct": _safe_pct(freemix),
-                        "site_count": row.get("#SNPS", snp_count),
-                        "read_count": row.get("#READS", ""),
-                        "mean_depth": row.get("AVG_DP", ""),
-                        "runtime_seconds": runtime_seconds,
-                        "runtime_minutes": _seconds_to_minutes(runtime_seconds),
-                        "task_cost": benchmark.get("task_cost", ""),
-                        "source_path": path,
-                        "benchmark_path": benchmark_path,
-                        "status": contam_row["status"],
-                    }
-                )
-            for path in input.gatk:
-                sample, external, aligner, deduper = _parse_contam_path(path)
-                sample_id = day_stage_sample_id(sample, aligner, deduper)
-                with open(path, newline="") as handle:
-                    rows = list(csv.DictReader(handle, delimiter="\t"))
-                row = rows[0] if rows else {}
-                freemix = row.get("FREEMIX", "")
-                contam_writer.writerow(
-                    {
-                        "sample_id": sample_id,
-                        "external_sample_id": external,
-                        "aligner": aligner,
-                        "deduper": deduper,
-                        "panel_id": "",
-                        "panel_label": "",
-                        "tool": "gatk",
-                        "method": "freemix",
-                        "contamination_fraction": freemix,
-                        "contamination_pct": _safe_pct(freemix),
-                        "ci_low_fraction": "",
-                        "ci_high_fraction": "",
-                        "unknown_contamination_fraction": "",
-                        "unknown_contamination_pct": "",
-                        "site_count": row.get("#SNPS", ""),
-                        "read_count": row.get("#READS", ""),
-                        "mean_depth": row.get("AVG_DP", ""),
-                        "svd_prefix": "",
-                        "source_path": path,
-                        "status": "ok" if freemix not in ["", "NA"] else "no_call",
-                    }
-                )
-            for path in input.site_mix:
-                sample, external, aligner, deduper = _parse_contam_path(path)
-                sample_id = day_stage_sample_id(sample, aligner, deduper)
-                with open(path, newline="") as handle:
-                    rows = list(csv.DictReader(handle, delimiter="\t"))
-                row = rows[0] if rows else {}
-                out_row = {
-                    "sample_id": sample_id,
-                    "external_sample_id": external,
-                    "aligner": aligner,
-                    "deduper": deduper,
-                    "panel_id": "",
-                    "panel_label": "",
-                    "tool": "site_mix",
-                    "method": row.get("method", "genotype_free_site_mix"),
-                    "contamination_fraction": row.get("contamination_fraction", ""),
-                    "contamination_pct": row.get("contamination_pct", ""),
-                    "ci_low_fraction": row.get("ci_low_fraction", ""),
-                    "ci_high_fraction": row.get("ci_high_fraction", ""),
-                    "unknown_contamination_fraction": row.get(
-                        "unknown_contamination_fraction", ""
-                    ),
-                    "unknown_contamination_pct": row.get("unknown_contamination_pct", ""),
-                    "site_count": row.get("site_count", ""),
-                    "read_count": row.get("read_count", ""),
-                    "mean_depth": row.get("mean_depth", ""),
-                    "svd_prefix": "",
-                    "source_path": path,
-                    "status": "ok"
-                    if row.get("contamination_fraction", "") not in ["", "NA"]
-                    else "no_call",
-                }
-                contam_writer.writerow(out_row)
-                site_writer.writerow(out_row)
-        with open(output.donors, "w", newline="") as donor_handle:
-            donor_writer = csv.DictWriter(
-                donor_handle, fieldnames=donor_fields, delimiter="\t"
-            )
-            donor_writer.writeheader()
-            for path in input.site_mix_donors:
-                sample, external, aligner, deduper = _parse_contam_path(path)
-                sample_id = day_stage_sample_id(sample, aligner, deduper)
-                with open(path, newline="") as handle:
-                    for row in csv.DictReader(handle, delimiter="\t"):
-                        donor_writer.writerow(
-                            {
-                                "sample_id": sample_id,
-                                "external_sample_id": external,
-                                "aligner": aligner,
-                                "deduper": deduper,
-                                "source_rank": row.get("source_rank", ""),
-                                "source_sample_id": row.get("source_sample_id", ""),
-                                "is_unknown_source": row.get("is_unknown_source", ""),
-                                "contamination_fraction": row.get(
-                                    "contamination_fraction", ""
-                                ),
-                                "contamination_pct": row.get("contamination_pct", ""),
-                                "single_source_delta_log_likelihood": row.get(
-                                    "single_source_delta_log_likelihood", ""
-                                ),
-                                "source_path": path,
-                            }
-                        )
+    params:
+        sample_map=_sample_external_ids_json,
+        panel_metadata=_verifybamid2_panel_metadata_json,
+    log:
+        MDIR + "other_reports/logs/contamination_custom_data.log",
+    shell:
+        """
+        set -euo pipefail
+        mkdir -p $(dirname {output.contamination:q}) $(dirname {log:q})
+        python workflow/scripts/compile_contamination_mqc.py \
+          --sample-map-json {params.sample_map:q} \
+          --panel-metadata-json {params.panel_metadata:q} \
+          --contamination-output {output.contamination:q} \
+          --vb2-comparison-output {output.vb2_comparison:q} \
+          --site-mix-output {output.site_mix:q} \
+          --donor-output {output.donors:q} \
+          --vb2 {input.vb2:q} \
+          --vb2-bench {input.vb2_bench:q} \
+          --gatk {input.gatk:q} \
+          --site-mix {input.site_mix:q} \
+          --site-mix-donors {input.site_mix_donors:q} \
+          > {log:q} 2>&1
+        """
 
 
 rule produce_site_mix_contam_estimate:  # TARGET: Produce genotype-free site-mix contamination estimates

--- a/workflow/rules/tiddit.smk
+++ b/workflow/rules/tiddit.smk
@@ -1,4 +1,4 @@
-0#### TIDDIT IS A MORE DAYERN sv CALLER
+#### TIDDIT IS A MORE DAYERN sv CALLER
 # -------------------------------------
 # It leverages snv calls and some population
 # freq data to do it's work. It is a
@@ -88,7 +88,39 @@ rule tiddit_sort_index:
 
 
 
-localrules: produce_tiddit,
+def _tiddit_sv_mqc_inputs(wildcards):
+    if "tiddit" not in sv_CALLERS:
+        return []
+    return expand(
+        MDIR
+        + "{sample}/align/{alnr}/{ddup}/sv/tiddit/{sample}.{alnr}.tiddit.sv.sort.vcf.gz",
+        sample=SSAMPS,
+        alnr=QC_CRAM_ALIGNERS,
+        ddup=DDUP,
+    )
+
+
+localrules:
+    tiddit_sv_mqc_gather,
+    produce_tiddit,
+
+
+rule tiddit_sv_mqc_gather:
+    input:
+        _tiddit_sv_mqc_inputs
+    output:
+        MDIR + "other_reports/tiddit_sv_mqc.tsv"
+    log:
+        MDIR + "other_reports/logs/tiddit_sv_custom_data.log"
+    container: None
+    shell:
+        """
+        set -euo pipefail
+        mkdir -p $(dirname {output:q}) $(dirname {log:q})
+        python workflow/scripts/tiddit_sv_to_multiqc.py \
+          --output {output:q} \
+          {input:q} > {log:q} 2>&1
+        """
 
 rule produce_tiddit:  # DEPRECATED TARGET: use produce_tiddit_sv_vcf
     priority: 45

--- a/workflow/scripts/compile_alignstats.py
+++ b/workflow/scripts/compile_alignstats.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Compile per-sample alignstats TSVs into MultiQC-ready aggregate TSVs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import shutil
+from pathlib import Path
+
+
+CORE_FIELDS = ["Sample", "base_sample", "aligner", "deduper"]
+
+
+def _path_context(path: str) -> dict[str, str]:
+    parts = Path(path).parts
+    for index, part in enumerate(parts):
+        if part == "align" and index >= 1 and index + 2 < len(parts):
+            return {
+                "base_sample": parts[index - 1],
+                "aligner": parts[index + 1],
+                "deduper": parts[index + 2],
+            }
+    return {"base_sample": "", "aligner": "", "deduper": ""}
+
+
+def _read_rows(path: str) -> list[dict[str, str]]:
+    with open(path, encoding="utf-8") as handle:
+        lines = [line.rstrip("\n") for line in handle if line.strip()]
+    if not lines:
+        return []
+
+    header = lines[0]
+    if "\t" in header:
+        reader = csv.DictReader(lines, delimiter="\t")
+        return [dict(row) for row in reader]
+
+    fields = header.split()
+    rows: list[dict[str, str]] = []
+    for line in lines[1:]:
+        values = line.split()
+        row = dict(zip(fields, values, strict=False))
+        rows.append(row)
+    return rows
+
+
+def _normalise_row(path: str, row: dict[str, str]) -> tuple[list[str], dict[str, str]]:
+    context = _path_context(path)
+    base_sample = context["base_sample"] or row.get("base_sample", "")
+    aligner = context["aligner"] or row.get("aligner", "")
+    deduper = context["deduper"] or row.get("deduper", "")
+    sample_id = ".".join(part for part in [base_sample, aligner, deduper] if part)
+
+    normalised = {
+        "Sample": sample_id or row.get("Sample", "") or row.get("sample", ""),
+        "base_sample": base_sample,
+        "aligner": aligner,
+        "deduper": deduper,
+    }
+    metric_fields: list[str] = []
+    for field, value in row.items():
+        if field in {"Sample", "sample", "base_sample", "aligner", "deduper", ""}:
+            continue
+        if field is None:
+            continue
+        metric_fields.append(field)
+        normalised[field] = value
+    return metric_fields, normalised
+
+
+def collect_rows(mdir: str) -> tuple[list[str], list[dict[str, str]]]:
+    mdir_prefix = mdir.rstrip("/") + "/"
+    paths = sorted(
+        glob.glob(f"{mdir_prefix}*/align/*/*/alignqc/alignstats/*alignstats.tsv")
+    )
+    rows: list[dict[str, str]] = []
+    metric_fieldnames: list[str] = []
+    for path in paths:
+        for row in _read_rows(path):
+            fields, normalised = _normalise_row(path, row)
+            for field in fields:
+                if field not in metric_fieldnames:
+                    metric_fieldnames.append(field)
+            rows.append(normalised)
+
+    fieldnames = CORE_FIELDS + metric_fieldnames
+    return fieldnames, rows
+
+
+def write_tsv(path: str, fieldnames: list[str], rows: list[dict[str, str]]) -> None:
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mdir", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--bsummary", required=True)
+    parser.add_argument("--csummary", required=True)
+    parser.add_argument("--combo", required=True)
+    parser.add_argument("--generalstats", required=True)
+    args = parser.parse_args()
+
+    fieldnames, rows = collect_rows(args.mdir)
+    log_path = Path(args.log)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as handle:
+        handle.write("STARTcompileAstats\n")
+        handle.write(f"rows\t{len(rows)}\n")
+        handle.write(f"columns\t{len(fieldnames)}\n")
+
+    write_tsv(args.bsummary, fieldnames, rows)
+    write_tsv(args.csummary, fieldnames, rows)
+    write_tsv(args.combo, fieldnames, rows)
+    shutil.copyfile(args.combo, args.generalstats)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow/scripts/compile_contamination_mqc.py
+++ b/workflow/scripts/compile_contamination_mqc.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Compile contamination QC outputs into MultiQC-ready custom TSVs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+CONTAMINATION_FIELDS = [
+    "Sample",
+    "sample_id",
+    "external_sample_id",
+    "aligner",
+    "deduper",
+    "panel_id",
+    "panel_label",
+    "tool",
+    "method",
+    "contamination_fraction",
+    "contamination_pct",
+    "ci_low_fraction",
+    "ci_high_fraction",
+    "unknown_contamination_fraction",
+    "unknown_contamination_pct",
+    "site_count",
+    "read_count",
+    "mean_depth",
+    "svd_prefix",
+    "source_path",
+    "status",
+]
+
+VB2_FIELDS = [
+    "Sample",
+    "sample_id",
+    "external_sample_id",
+    "aligner",
+    "deduper",
+    "panel_id",
+    "panel_label",
+    "snp_count",
+    "svd_prefix",
+    "freemix_fraction",
+    "contamination_pct",
+    "site_count",
+    "read_count",
+    "mean_depth",
+    "runtime_seconds",
+    "runtime_minutes",
+    "task_cost",
+    "source_path",
+    "benchmark_path",
+    "status",
+]
+
+DONOR_FIELDS = [
+    "Sample",
+    "sample_id",
+    "external_sample_id",
+    "aligner",
+    "deduper",
+    "source_rank",
+    "source_sample_id",
+    "is_unknown_source",
+    "contamination_fraction",
+    "contamination_pct",
+    "single_source_delta_log_likelihood",
+    "source_path",
+]
+
+
+def _safe_pct(value: str | None) -> str:
+    try:
+        return str(float(value) * 100.0)
+    except (TypeError, ValueError):
+        return ""
+
+
+def _seconds_to_minutes(value: str | None) -> str:
+    try:
+        return str(float(value) / 60.0)
+    except (TypeError, ValueError):
+        return ""
+
+
+def _stage_sample_id(sample: str, aligner: str, deduper: str) -> str:
+    return ".".join(part for part in [sample, aligner, deduper] if part)
+
+
+def _path_context(path: str) -> tuple[str, str, str]:
+    parts = Path(path).parts
+    for index, part in enumerate(parts):
+        if part == "align" and index >= 1 and index + 2 < len(parts):
+            return parts[index - 1], parts[index + 1], parts[index + 2]
+    raise ValueError(f"Malformed contamination path: {path}")
+
+
+def _parse_contam_path(path: str, sample_map: dict[str, str]) -> tuple[str, str, str, str]:
+    sample, aligner, deduper = _path_context(path)
+    return sample, sample_map.get(sample, sample), aligner, deduper
+
+
+def _parse_vb2_panel_path(
+    path: str, sample_map: dict[str, str]
+) -> tuple[str, str, str, str, str]:
+    sample, external, aligner, deduper = _parse_contam_path(path, sample_map)
+    parts = list(Path(path).parts)
+    try:
+        panel = parts[parts.index("vb2") + 1]
+    except (ValueError, IndexError) as exc:
+        raise ValueError(f"Malformed panel-aware VerifyBamID2 path: {path}") from exc
+    return sample, external, aligner, deduper, panel
+
+
+def _parse_benchmark_path(path: str) -> tuple[str, str, str, str] | None:
+    name = Path(path).name
+    suffix = ".vb2.bench.tsv"
+    if not name.endswith(suffix):
+        return None
+    stem = name[: -len(suffix)]
+    try:
+        sample, aligner, deduper, panel = stem.rsplit(".", 3)
+    except ValueError:
+        return None
+    return sample, aligner, deduper, panel
+
+
+def _read_first_row(path: str) -> dict[str, str]:
+    try:
+        with open(path, newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle, delimiter="\t"))
+    except OSError:
+        return {}
+    return rows[0] if rows else {}
+
+
+def _benchmark_by_vb2_key(paths: list[str]) -> dict[tuple[str, str, str, str], str]:
+    benchmarks: dict[tuple[str, str, str, str], str] = {}
+    for path in paths:
+        key = _parse_benchmark_path(path)
+        if key is not None:
+            benchmarks[key] = path
+    return benchmarks
+
+
+def _write_header(path: str, fieldnames: list[str]) -> csv.DictWriter:
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = out_path.open("w", newline="", encoding="utf-8")
+    writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+    writer.writeheader()
+    writer._dayoa_handle = handle  # type: ignore[attr-defined]
+    return writer
+
+
+def _close_writer(writer: csv.DictWriter) -> None:
+    handle = getattr(writer, "_dayoa_handle")
+    handle.close()
+
+
+def compile_reports(args: argparse.Namespace) -> None:
+    sample_map = json.loads(args.sample_map_json)
+    panel_metadata = json.loads(args.panel_metadata_json)
+    contam_writer = _write_header(args.contamination_output, CONTAMINATION_FIELDS)
+    site_writer = _write_header(args.site_mix_output, CONTAMINATION_FIELDS)
+    vb2_writer = _write_header(args.vb2_comparison_output, VB2_FIELDS)
+    donor_writer = _write_header(args.donor_output, DONOR_FIELDS)
+
+    try:
+        vb2_benchmarks = _benchmark_by_vb2_key(args.vb2_bench)
+        for path in args.vb2:
+            sample, external, aligner, deduper, panel_id = _parse_vb2_panel_path(
+                path, sample_map
+            )
+            sample_id = _stage_sample_id(sample, aligner, deduper)
+            row = _read_first_row(path)
+            freemix = row.get("FREEMIX", "")
+            panel_cfg = panel_metadata.get(panel_id, {})
+            benchmark_path = vb2_benchmarks.get((sample, aligner, deduper, panel_id), "")
+            benchmark = _read_first_row(benchmark_path)
+            runtime_seconds = benchmark.get("s", "")
+            panel_label = str(panel_cfg.get("label", panel_id))
+            snp_count = str(panel_cfg.get("snp_count", row.get("#SNPS", "")))
+            svd_prefix = str(panel_cfg.get("svd_prefix", ""))
+            contam_row = {
+                "Sample": sample_id,
+                "sample_id": sample_id,
+                "external_sample_id": external,
+                "aligner": aligner,
+                "deduper": deduper,
+                "panel_id": panel_id,
+                "panel_label": panel_label,
+                "tool": "verifybamid2",
+                "method": "freemix",
+                "contamination_fraction": freemix,
+                "contamination_pct": _safe_pct(freemix),
+                "ci_low_fraction": "",
+                "ci_high_fraction": "",
+                "unknown_contamination_fraction": "",
+                "unknown_contamination_pct": "",
+                "site_count": row.get("#SNPS", snp_count),
+                "read_count": row.get("#READS", ""),
+                "mean_depth": row.get("AVG_DP", ""),
+                "svd_prefix": svd_prefix,
+                "source_path": path,
+                "status": "ok" if freemix not in ["", "NA"] else "no_call",
+            }
+            contam_writer.writerow(contam_row)
+            vb2_writer.writerow(
+                {
+                    "Sample": sample_id,
+                    "sample_id": sample_id,
+                    "external_sample_id": external,
+                    "aligner": aligner,
+                    "deduper": deduper,
+                    "panel_id": panel_id,
+                    "panel_label": panel_label,
+                    "snp_count": snp_count,
+                    "svd_prefix": svd_prefix,
+                    "freemix_fraction": freemix,
+                    "contamination_pct": _safe_pct(freemix),
+                    "site_count": row.get("#SNPS", snp_count),
+                    "read_count": row.get("#READS", ""),
+                    "mean_depth": row.get("AVG_DP", ""),
+                    "runtime_seconds": runtime_seconds,
+                    "runtime_minutes": _seconds_to_minutes(runtime_seconds),
+                    "task_cost": benchmark.get("task_cost", ""),
+                    "source_path": path,
+                    "benchmark_path": benchmark_path,
+                    "status": contam_row["status"],
+                }
+            )
+
+        for path in args.gatk:
+            sample, external, aligner, deduper = _parse_contam_path(path, sample_map)
+            sample_id = _stage_sample_id(sample, aligner, deduper)
+            row = _read_first_row(path)
+            freemix = row.get("FREEMIX", "")
+            contam_writer.writerow(
+                {
+                    "Sample": sample_id,
+                    "sample_id": sample_id,
+                    "external_sample_id": external,
+                    "aligner": aligner,
+                    "deduper": deduper,
+                    "panel_id": "",
+                    "panel_label": "",
+                    "tool": "gatk",
+                    "method": "freemix",
+                    "contamination_fraction": freemix,
+                    "contamination_pct": _safe_pct(freemix),
+                    "ci_low_fraction": "",
+                    "ci_high_fraction": "",
+                    "unknown_contamination_fraction": "",
+                    "unknown_contamination_pct": "",
+                    "site_count": row.get("#SNPS", ""),
+                    "read_count": row.get("#READS", ""),
+                    "mean_depth": row.get("AVG_DP", ""),
+                    "svd_prefix": "",
+                    "source_path": path,
+                    "status": "ok" if freemix not in ["", "NA"] else "no_call",
+                }
+            )
+
+        for path in args.site_mix:
+            sample, external, aligner, deduper = _parse_contam_path(path, sample_map)
+            sample_id = _stage_sample_id(sample, aligner, deduper)
+            row = _read_first_row(path)
+            out_row = {
+                "Sample": sample_id,
+                "sample_id": sample_id,
+                "external_sample_id": external,
+                "aligner": aligner,
+                "deduper": deduper,
+                "panel_id": "",
+                "panel_label": "",
+                "tool": "site_mix",
+                "method": row.get("method", "genotype_free_site_mix"),
+                "contamination_fraction": row.get("contamination_fraction", ""),
+                "contamination_pct": row.get("contamination_pct", ""),
+                "ci_low_fraction": row.get("ci_low_fraction", ""),
+                "ci_high_fraction": row.get("ci_high_fraction", ""),
+                "unknown_contamination_fraction": row.get(
+                    "unknown_contamination_fraction", ""
+                ),
+                "unknown_contamination_pct": row.get("unknown_contamination_pct", ""),
+                "site_count": row.get("site_count", ""),
+                "read_count": row.get("read_count", ""),
+                "mean_depth": row.get("mean_depth", ""),
+                "svd_prefix": "",
+                "source_path": path,
+                "status": "ok"
+                if row.get("contamination_fraction", "") not in ["", "NA"]
+                else "no_call",
+            }
+            contam_writer.writerow(out_row)
+            site_writer.writerow(out_row)
+
+        for path in args.site_mix_donors:
+            sample, external, aligner, deduper = _parse_contam_path(path, sample_map)
+            sample_id = _stage_sample_id(sample, aligner, deduper)
+            with open(path, newline="", encoding="utf-8") as handle:
+                for row in csv.DictReader(handle, delimiter="\t"):
+                    donor_writer.writerow(
+                        {
+                            "Sample": sample_id,
+                            "sample_id": sample_id,
+                            "external_sample_id": external,
+                            "aligner": aligner,
+                            "deduper": deduper,
+                            "source_rank": row.get("source_rank", ""),
+                            "source_sample_id": row.get("source_sample_id", ""),
+                            "is_unknown_source": row.get("is_unknown_source", ""),
+                            "contamination_fraction": row.get(
+                                "contamination_fraction", ""
+                            ),
+                            "contamination_pct": row.get("contamination_pct", ""),
+                            "single_source_delta_log_likelihood": row.get(
+                                "single_source_delta_log_likelihood", ""
+                            ),
+                            "source_path": path,
+                        }
+                    )
+    finally:
+        for writer in (contam_writer, site_writer, vb2_writer, donor_writer):
+            _close_writer(writer)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sample-map-json", required=True)
+    parser.add_argument("--panel-metadata-json", required=True)
+    parser.add_argument("--contamination-output", required=True)
+    parser.add_argument("--vb2-comparison-output", required=True)
+    parser.add_argument("--site-mix-output", required=True)
+    parser.add_argument("--donor-output", required=True)
+    parser.add_argument("--vb2", nargs="*", default=[])
+    parser.add_argument("--vb2-bench", nargs="*", default=[])
+    parser.add_argument("--gatk", nargs="*", default=[])
+    parser.add_argument("--site-mix", nargs="*", default=[])
+    parser.add_argument("--site-mix-donors", nargs="*", default=[])
+    args = parser.parse_args()
+    compile_reports(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow/scripts/multiqc_log_guard.py
+++ b/workflow/scripts/multiqc_log_guard.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Keep DayOA operational logs out of MultiQC custom-content discovery."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def guard_log_dir(log_dir: Path) -> list[Path]:
+    renamed: list[Path] = []
+    if not log_dir.exists():
+        return renamed
+
+    bad_logs = sorted(path for path in log_dir.glob("*_mqc.log") if path.stat().st_size)
+    if bad_logs:
+        joined = "\n".join(str(path) for path in bad_logs)
+        raise SystemExit(
+            "ERROR: non-empty *_mqc.log files are not valid DayOA MultiQC inputs. "
+            "Convert reportable metrics to *_mqc.tsv or *_mqc.csv and keep logs "
+            f"out of other_reports/logs:\n{joined}"
+        )
+
+    for path in sorted(log_dir.glob("*_mqc.log")):
+        target = path.with_name(path.name.removesuffix("_mqc.log") + "_legacy_custom_data.log")
+        path.rename(target)
+        renamed.append(target)
+    return renamed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    renamed = guard_log_dir(args.log_dir)
+    for path in renamed:
+        print(f"renamed_zero_byte_mqc_log\t{path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow/scripts/tiddit_sv_to_multiqc.py
+++ b/workflow/scripts/tiddit_sv_to_multiqc.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Summarize TIDDIT SV VCFs as a MultiQC custom-data TSV."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import re
+from pathlib import Path
+from typing import TextIO
+
+
+TIDDIT_PATH_RE = re.compile(
+    r"(?P<sample>[^/]+)/align/(?P<aligner>[^/]+)/(?P<deduper>[^/]+)/sv/tiddit/"
+)
+SVTYPE_KEYS = ("DEL", "DUP", "INV", "INS", "BND", "TRA")
+FIELDNAMES = [
+    "Sample",
+    "base_sample",
+    "aligner",
+    "deduper",
+    "sv_caller",
+    "total_records",
+    "DEL",
+    "DUP",
+    "INV",
+    "INS",
+    "BND",
+    "TRA",
+    "other_svtype",
+    "no_svtype",
+    "vcf_path",
+    "status",
+]
+
+
+def stage_sample_id(sample: str, aligner: str, deduper: str, sv_caller: str) -> str:
+    return ".".join([sample, aligner, deduper, sv_caller])
+
+
+def parse_tiddit_path(path: str) -> tuple[str, str, str]:
+    match = TIDDIT_PATH_RE.search(path)
+    if not match:
+        raise ValueError(f"Malformed TIDDIT VCF path: {path}")
+    return match.group("sample"), match.group("aligner"), match.group("deduper")
+
+
+def open_text(path: Path) -> TextIO:
+    if path.name.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8")
+    return path.open("r", encoding="utf-8")
+
+
+def parse_info_svtype(info: str) -> str:
+    for part in info.split(";"):
+        if part.startswith("SVTYPE="):
+            return part.split("=", 1)[1].strip()
+    return ""
+
+
+def summarize_vcf(path_text: str) -> dict[str, str | int]:
+    sample, aligner, deduper = parse_tiddit_path(path_text)
+    path = Path(path_text)
+    counts = {key: 0 for key in SVTYPE_KEYS}
+    total_records = 0
+    other_svtype = 0
+    no_svtype = 0
+    status = "ok"
+
+    if not path.exists():
+        status = "missing"
+    else:
+        with open_text(path) as handle:
+            for line in handle:
+                if not line or line.startswith("#"):
+                    continue
+                total_records += 1
+                fields = line.rstrip("\n").split("\t")
+                svtype = parse_info_svtype(fields[7] if len(fields) > 7 else "")
+                if not svtype:
+                    no_svtype += 1
+                elif svtype in counts:
+                    counts[svtype] += 1
+                else:
+                    other_svtype += 1
+        if total_records == 0:
+            status = "no_records"
+
+    return {
+        "Sample": stage_sample_id(sample, aligner, deduper, "tiddit"),
+        "base_sample": sample,
+        "aligner": aligner,
+        "deduper": deduper,
+        "sv_caller": "tiddit",
+        "total_records": total_records,
+        "DEL": counts["DEL"],
+        "DUP": counts["DUP"],
+        "INV": counts["INV"],
+        "INS": counts["INS"],
+        "BND": counts["BND"],
+        "TRA": counts["TRA"],
+        "other_svtype": other_svtype,
+        "no_svtype": no_svtype,
+        "vcf_path": path_text,
+        "status": status,
+    }
+
+
+def write_summary(paths: list[str], output: str) -> None:
+    rows = [summarize_vcf(path) for path in paths]
+    rows.sort(key=lambda row: str(row["Sample"]))
+    out_path = Path(output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("vcfs", nargs="*")
+    args = parser.parse_args()
+    write_summary(args.vcfs, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- fix DayOA custom MultiQC section generation for alignstats, contamination, site_mix, and TIDDIT
- switch MultiQC runtime rules to official multiqc/multiqc:v1.35 and log the runtime version without hard-failing on it
- keep operational *_mqc.log files out of custom-content discovery and re-enable native peddy/somalier modules

## Tests
- python -m pytest -q tests/test_multiqc_qc_targets.py tests/test_multiqc_sample_identifiers.py tests/test_workflow_catalog.py
- ruff check workflow/scripts tests
- git diff --check