### PR TITLE
Validate multi FASTQ ordering and skip-budget clusters

### DIFF
--- a/bin/qc_fastq_files_for_read_order_matching.sh
+++ b/bin/qc_fastq_files_for_read_order_matching.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: ./fastq_qc.sh <skip> <R1_1.fastq(.gz)> <R2_1.fastq(.gz)> ...
 # Example: ./fastq_qc.sh 10000 R1_1.fastq.gz R2_1.fastq R1_2.fastq.gz R2_2.fastq
+
+set -euo pipefail
 
 if [[ $# -lt 3 || $((($# - 1) % 2)) -ne 0 ]]; then
     echo "Usage: $0 <skip> <R1_1.fastq(.gz)> <R2_1.fastq(.gz)> ..."
@@ -11,21 +13,49 @@ fi
 # Get the skip value and shift the arguments to get the file list
 SKIP=$1
 shift
+if ! [[ "$SKIP" =~ ^[0-9]+$ ]] || [[ "$SKIP" -lt 1 ]]; then
+    echo "skip must be a positive integer" >&2
+    exit 1
+fi
 
-# Function to count reads with skipping
+# Function to read FASTQ content.
+fastq_reader() {
+    local file=$1
+    if [[ "$file" == *.gz ]]; then
+        gzip -dc -- "$file"
+    else
+        cat -- "$file"
+    fi
+}
+
 count_reads() {
     local file=$1
+    fastq_reader "$file" | awk 'END { if (NR % 4 != 0) exit 2; print NR / 4 }'
+}
+
+first_read_name() {
+    local file=$1
+    fastq_reader "$file" | awk 'NR == 1 { print; exit }'
+}
+
+last_read_name() {
+    local file=$1
+    fastq_reader "$file" | awk 'NR % 4 == 1 { header=$0 } END { if (header == "") exit 2; print header }'
+}
+
+sampled_read_names() {
+    local file=$1
     local skip=$2
+    fastq_reader "$file" | awk -v skip="$skip" 'NR % 4 == 1 && (((NR - 1) / 4) % skip == 0) { print }'
+}
 
-    # Check if the file is gzipped or not
-    if [[ "$file" == *.gz ]]; then
-        reader="zcat"
-    else
-        reader="cat"
-    fi
-
-    # Use the appropriate reader (zcat or cat) and count reads by skipping
-    $reader "$file" | awk -v skip="$skip" 'NR % (4 * skip) == 1' | wc -l
+normalize_read_name() {
+    local raw=$1
+    raw=${raw#@}
+    raw=${raw%%[[:space:]]*}
+    raw=${raw%/1}
+    raw=${raw%/2}
+    printf '%s\n' "$raw"
 }
 
 # Function to compare two FASTQ files
@@ -33,29 +63,55 @@ compare_fastq_pair() {
     local r1=$1
     local r2=$2
 
-    r1_count=$(count_reads "$r1" "$SKIP")
-    r2_count=$(count_reads "$r2" "$SKIP")
+    local r1_count
+    local r2_count
+    r1_count=$(count_reads "$r1")
+    r2_count=$(count_reads "$r2")
 
     if [[ "$r1_count" -ne "$r2_count" ]]; then
-        echo "❌ Mismatch: $r1 ($r1_count reads) and $r2 ($r2_count reads)"
+        echo "Mismatch: $r1 ($r1_count reads) and $r2 ($r2_count reads)"
         return 1
-    else
-        echo "✅ Paired correctly: $r1 and $r2 ($r1_count reads)"
-        return 0
     fi
+
+    local r1_first
+    local r2_first
+    local r1_last
+    local r2_last
+    r1_first=$(normalize_read_name "$(first_read_name "$r1")")
+    r2_first=$(normalize_read_name "$(first_read_name "$r2")")
+    r1_last=$(normalize_read_name "$(last_read_name "$r1")")
+    r2_last=$(normalize_read_name "$(last_read_name "$r2")")
+
+    if [[ "$r1_first" != "$r2_first" ]]; then
+        echo "First read mismatch: $r1 has $r1_first; $r2 has $r2_first"
+        return 1
+    fi
+    if [[ "$r1_last" != "$r2_last" ]]; then
+        echo "Last read mismatch: $r1 has $r1_last; $r2 has $r2_last"
+        return 1
+    fi
+
+    if ! diff -u <(sampled_read_names "$r1" "$SKIP" | while read -r read_name; do normalize_read_name "$read_name"; done) \
+        <(sampled_read_names "$r2" "$SKIP" | while read -r read_name; do normalize_read_name "$read_name"; done) >/dev/null; then
+        echo "Sampled read-order mismatch: $r1 and $r2 differ with skip=$SKIP"
+        return 1
+    fi
+
+    echo "Paired correctly: $r1 and $r2 ($r1_count reads; first=$r1_first last=$r1_last)"
+    return 0
 }
 
-# Export functions for GNU Parallel
-export -f count_reads
-export -f compare_fastq_pair
-export SKIP
+status=0
+while [[ $# -gt 0 ]]; do
+    if ! compare_fastq_pair "$1" "$2"; then
+        status=1
+    fi
+    shift 2
+done
 
-# Run comparisons in parallel
-parallel --will-cite --jobs 4 compare_fastq_pair ::: "$@"
-
-# Check if all comparisons passed
-if [[ $? -eq 0 ]]; then
-    echo "🎉 All FASTQ pairs passed QC!"
+if [[ "$status" -eq 0 ]]; then
+    echo "All FASTQ pairs passed QC."
 else
-    echo "⚠️ Some FASTQ pairs failed QC. See above for details."
+    echo "Some FASTQ pairs failed QC. See above for details."
 fi
+exit "$status"

--- a/dyoainit
+++ b/dyoainit
@@ -52,6 +52,25 @@ command_exists() {
     command -v "$1" &> /dev/null
 }
 
+cluster_config_tag_value() {
+    local tag_key="$1"
+    local config_file="${2:-/opt/parallelcluster/shared/cluster-config.yaml}"
+    if [[ ! -f "$config_file" ]]; then
+        return 1
+    fi
+    awk -v tag_key="$tag_key" '
+        $1 == "-" && $2 == "Key:" && $3 == tag_key {
+            getline
+            if ($1 == "Value:") {
+                print $2
+                found = 1
+                exit
+            }
+        }
+        END { exit(found ? 0 : 1) }
+    ' "$config_file"
+}
+
 day_current_user() {
     local current_user="${USER:-}"
     if [[ -z "$current_user" ]]; then
@@ -121,11 +140,16 @@ fi
 
 
 # Set default project name if not provided
+cluster_config_file="/opt/parallelcluster/shared/cluster-config.yaml"
+BUDGET_ENFORCEMENT=""
+if [[ -f "$cluster_config_file" ]]; then
+    BUDGET_ENFORCEMENT="$(cluster_config_tag_value "aws-parallelcluster-enforce-budget" "$cluster_config_file" || true)"
+fi
 if [[ -z "$PROJECT" ]]; then
-    if [[ -f "/opt/parallelcluster/shared/cluster-config.yaml" ]]; then
-        PROJECT=$(awk '/Key: aws-parallelcluster-project/ {getline; print $2}' /opt/parallelcluster/shared/cluster-config.yaml)
+    if [[ -f "$cluster_config_file" ]]; then
+        PROJECT="$(cluster_config_tag_value "aws-parallelcluster-project" "$cluster_config_file" || true)"
         if [[ -z "$PROJECT" ]]; then
-            echo "Error: Project tag aws-parallelcluster-project was not found in /opt/parallelcluster/shared/cluster-config.yaml"
+            echo "Error: Project tag aws-parallelcluster-project was not found in $cluster_config_file"
             return 3
         fi
         echo "Notice: --project not set. Using default project name: $PROJECT"
@@ -135,6 +159,11 @@ if [[ -z "$PROJECT" ]]; then
     fi
 fi
 
+if [[ "$BUDGET_ENFORCEMENT" == "skip" && "$SKIP_PROJECT_CHECK" == false ]]; then
+    echo "Notice: Cluster config sets aws-parallelcluster-enforce-budget=skip; skipping project validation."
+    SKIP_PROJECT_CHECK=true
+fi
+
 # Display the parsed values
 echo "Project: $PROJECT"
 echo "Skip Project Check: $SKIP_PROJECT_CHECK"
@@ -142,14 +171,7 @@ echo "Skip Project Check: $SKIP_PROJECT_CHECK"
 # Export environment variables
 export DAY_PROJECT="$PROJECT"
 export DAY_AWS_REGION="$region"
-
-
-# Get AWS Account ID
-export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
-if [[ -z "$AWS_ACCOUNT_ID" ]]; then
-    echo "Error: Unable to retrieve AWS Account ID."
-    return 3
-fi
+export AWS_ACCOUNT_ID="NA"
 
 # Skip project check if the flag is provided
 if [[ "$SKIP_PROJECT_CHECK" == false ]]; then
@@ -205,6 +227,13 @@ if [[ "$SKIP_PROJECT_CHECK" == true ]]; then
     echo "  Percent Used: $PERCENT_USED"
     echo "________________________________________________________"
 else
+    # Get AWS Account ID
+    export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+    if [[ -z "$AWS_ACCOUNT_ID" ]]; then
+        echo "Error: Unable to retrieve AWS Account ID."
+        return 3
+    fi
+
     if ! command_exists jq; then
         echo "Error: jq is required to parse AWS budget JSON."
         return 3

--- a/tests/test_fastq_pair_order_qc.py
+++ b/tests/test_fastq_pair_order_qc.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import gzip
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QC_SCRIPT = REPO_ROOT / "bin" / "qc_fastq_files_for_read_order_matching.sh"
+
+
+def _write_fastq(path: Path, names: list[str], *, mate: str) -> None:
+    suffix = "/1" if mate == "R1" else "/2"
+    with gzip.open(path, "wt", encoding="utf-8") as handle:
+        for name in names:
+            handle.write(f"@{name}{suffix}\n")
+            handle.write("ACGT\n")
+            handle.write("+\n")
+            handle.write("IIII\n")
+
+
+def test_qc_fastq_pair_order_accepts_matching_first_last_and_sampled_reads(
+    tmp_path: Path,
+) -> None:
+    r1 = tmp_path / "lane001.R1.fastq.gz"
+    r2 = tmp_path / "lane001.R2.fastq.gz"
+    _write_fastq(r1, ["read001", "read002", "read003", "read004"], mate="R1")
+    _write_fastq(r2, ["read001", "read002", "read003", "read004"], mate="R2")
+
+    result = subprocess.run(
+        ["bash", str(QC_SCRIPT), "2", str(r1), str(r2)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0
+    assert "Paired correctly" in result.stdout
+    assert "first=read001 last=read004" in result.stdout
+
+
+def test_qc_fastq_pair_order_rejects_last_read_mismatch(tmp_path: Path) -> None:
+    r1 = tmp_path / "lane001.R1.fastq.gz"
+    r2 = tmp_path / "lane001.R2.fastq.gz"
+    _write_fastq(r1, ["read001", "read002", "read003", "read004"], mate="R1")
+    _write_fastq(r2, ["read001", "read002", "read003", "read999"], mate="R2")
+
+    result = subprocess.run(
+        ["bash", str(QC_SCRIPT), "2", str(r1), str(r2)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert "Last read mismatch" in result.stdout
+    assert "read004" in result.stdout
+    assert "read999" in result.stdout
+

--- a/tests/test_shell_wrapper_contracts.py
+++ b/tests/test_shell_wrapper_contracts.py
@@ -165,8 +165,16 @@ def test_dyoainit_budget_and_optional_variable_contracts() -> None:
     assert 'export TOTAL_BUDGET="NA"' in dyoainit
     assert 'export USED_BUDGET="NA"' in dyoainit
     assert 'export PERCENT_USED="NA"' in dyoainit
+    assert 'export AWS_ACCOUNT_ID="NA"' in dyoainit
     assert "bc -l" not in dyoainit
     assert "DEFAULTING TO PROJECT=daylily-global" not in dyoainit
+
+    assert "cluster_config_tag_value()" in dyoainit
+    assert "aws-parallelcluster-enforce-budget" in dyoainit
+    assert "Notice: Cluster config sets aws-parallelcluster-enforce-budget=skip" in dyoainit
+    assert dyoainit.index('if [[ "$SKIP_PROJECT_CHECK" == true ]]; then') < dyoainit.index(
+        "aws sts get-caller-identity"
+    )
 
     assert "day_current_user()" in dyoainit
     assert "id -un" in dyoainit


### PR DESCRIPTION
## Summary

- Tighten FASTQ pair-order QC for comma-separated ILMN R1/R2 inputs so split lane files can be checked before workflow execution.
- Update `dyoainit` to honor skip-budget cluster handling.
- Add focused regression coverage for the FASTQ order checker and shell wrapper contracts.

## Validation

- `python -m pytest -q tests/test_fastq_pair_order_qc.py tests/test_shell_wrapper_contracts.py`
- `bash -n bin/qc_fastq_files_for_read_order_matching.sh`
- `bash -n dyoainit`
